### PR TITLE
Add Read Input register response and fix logger

### DIFF
--- a/src/Network/BinaryStreamConnection.php
+++ b/src/Network/BinaryStreamConnection.php
@@ -103,7 +103,7 @@ class BinaryStreamConnection extends BinaryStreamConnectionProperties
                     $data .= fread($this->streamSocket, 2048); // read max 2048 bytes
                     if (!empty($data)) {
                         if ($this->logger) {
-                            $this->logger->debug('Data received: ' . unpack('H*', $data));
+                            $this->logger->debug('Data received', unpack('H*', $data));
                         }
                         return $data;
                     }
@@ -126,7 +126,7 @@ class BinaryStreamConnection extends BinaryStreamConnectionProperties
         fwrite($this->streamSocket, $packet, strlen($packet));
 
         if ($this->logger) {
-            $this->logger->debug('Data sent: ' . unpack('H*', $packet));
+            $this->logger->debug('Data sent.', unpack('H*', $packet));
         }
 
         return $this;

--- a/src/Packet/ResponseFactory.php
+++ b/src/Packet/ResponseFactory.php
@@ -7,6 +7,7 @@ namespace ModbusTcpClient\Packet;
 use ModbusTcpClient\ModbusException;
 use ModbusTcpClient\Packet\ModbusFunction\ReadCoilsResponse;
 use ModbusTcpClient\Packet\ModbusFunction\ReadHoldingRegistersResponse;
+use ModbusTcpClient\Packet\ModbusFunction\ReadInputRegistersResponse;
 use ModbusTcpClient\Packet\ModbusFunction\WriteMultipleCoilsResponse;
 use ModbusTcpClient\Packet\ModbusFunction\WriteMultipleRegistersResponse;
 use ModbusTcpClient\Packet\ModbusFunction\WriteSingleCoilResponse;
@@ -48,6 +49,8 @@ class ResponseFactory
             case ModbusPacket::READ_HOLDING_REGISTERS:
                 return new ReadHoldingRegistersResponse($rawData, $unitId, $transactionId);
                 break;
+            case ModbusPacket::READ_INPUT_REGISTERS:
+                return new ReadInputRegistersResponse($rawData, $unitId, $transactionId);
             case ModbusPacket::READ_COILS:
                 return new ReadCoilsResponse($rawData, $unitId, $transactionId);
                 break;


### PR DESCRIPTION
This complies with psr/logger interface and uses the context argument to pass unpack data.

unpack returns an array instead of a string, this causes a "array to string conversion notice".