### PR TITLE
bugfix: method name in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ $fc3 = ReadRegistersBuilder::newReadHoldingRegisters('tcp://127.0.0.1:5022')
     ->build(); // returns array of 3 ReadHoldingRegistersRequest requests
 
 // this will use PHP non-blocking stream io to recieve responses
-$responses = (new NonBlockingClient(['readTimeoutSec' => 0.2]))->sendReadRequests($fc3);
+$responses = (new NonBlockingClient(['readTimeoutSec' => 0.2]))->sendRequests($fc3);
 print_r($responses);
 ```
 Response structure


### PR DESCRIPTION
method name was probably left from an old version