### PR TITLE
Fix ResultContainer::offsetGet() return type

### DIFF
--- a/src/Network/ResultContainer.php
+++ b/src/Network/ResultContainer.php
@@ -46,7 +46,7 @@ class ResultContainer implements \ArrayAccess, \IteratorAggregate
         return isset($this->data[$offset]);
     }
 
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->data[$offset] ?? null;
     }


### PR DESCRIPTION
Fix PHP 8.1 deprecated warning

---

First, thank a lot for you work on this library, it's help me a lot.  
But, recently I moved to PHP 8.1 with 2.4 version.  
I had several deprecation, and I saw you release a 3.0 version with several fixes for PHP 8.1 type system.  
But, it's look like you miss one.  
This PR is to fix this.  

I don't know if it was intentionally for some backup compatibilty.  
So, maybe I can suggest to add [`#[ReturnTypeWillChange]`](https://www.php.net/manual/en/migration81.incompatible.php#migration81.incompatible.core.type-compatibility-internal)