### PR TITLE
Made `Compose/*Builder` classes `*AddressSplitter` field protected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [3.2.0] - 2023-XX-xX
+
+* Made `Compose/*Builder` classes `*AddressSplitter` field protected so extending classes can change that field.
+
+
 # [3.1.1] - 2023-01-25
 
 * Fixed `Packet::isCompleteLengthRTU()` to differentiate fix sized function code responses from variable sized responses.

--- a/src/Composer/Read/ReadCoilsBuilder.php
+++ b/src/Composer/Read/ReadCoilsBuilder.php
@@ -15,7 +15,7 @@ use ModbusTcpClient\Packet\ModbusFunction\ReadInputDiscretesRequest;
 class ReadCoilsBuilder
 {
     /** @var ReadCoilAddressSplitter */
-    private ReadCoilAddressSplitter $addressSplitter;
+    protected ReadCoilAddressSplitter $addressSplitter;
 
     /**
      * @var array<array<string,ReadCoilAddress>>

--- a/src/Composer/Read/ReadRegistersBuilder.php
+++ b/src/Composer/Read/ReadRegistersBuilder.php
@@ -20,7 +20,7 @@ use ModbusTcpClient\Utils\Endian;
 class ReadRegistersBuilder
 {
     /** @var ReadRegisterAddressSplitter */
-    private ReadRegisterAddressSplitter $addressSplitter;
+    protected ReadRegisterAddressSplitter $addressSplitter;
 
     /**
      * @var array<array<string, ReadRegisterAddress>>

--- a/src/Composer/Write/WriteCoilsBuilder.php
+++ b/src/Composer/Write/WriteCoilsBuilder.php
@@ -14,7 +14,7 @@ use ModbusTcpClient\Packet\ModbusFunction\WriteMultipleCoilsRequest;
 class WriteCoilsBuilder
 {
     /** @var WriteCoilAddressSplitter */
-    private WriteCoilAddressSplitter $addressSplitter;
+    protected WriteCoilAddressSplitter $addressSplitter;
 
     /** @var array<array<string,WriteCoilAddress>> */
     private array $addresses = [];

--- a/src/Composer/Write/WriteRegistersBuilder.php
+++ b/src/Composer/Write/WriteRegistersBuilder.php
@@ -16,7 +16,7 @@ use ModbusTcpClient\Packet\ModbusFunction\WriteMultipleRegistersRequest;
 class WriteRegistersBuilder
 {
     /** @var WriteRegisterAddressSplitter */
-    private WriteRegisterAddressSplitter $addressSplitter;
+    protected WriteRegisterAddressSplitter $addressSplitter;
 
     /** @var array<array<string,WriteRegisterAddress>> */
     private array $addresses = [];


### PR DESCRIPTION
Made `Compose/*Builder` classes `*AddressSplitter` field protected so extending classes can change that field.

Resolves #135