### PR TITLE
Endian fixes

### DIFF
--- a/examples/index.php
+++ b/examples/index.php
@@ -15,7 +15,11 @@ use ModbusTcpClient\Utils\Packet;
 // sudo udevadm control --reload-rules && sudo udevadm trigger
 $deviceURI = '/dev/ttyUSB0'; // do not make this changeable from WEB. This could be serious security risk.
 $isSerialDevice = false; // change to true to enable reading serial devices. this will disable ip/port logic and uses RTU
-if (getenv('MODBUS_SERIAL_ENABLED')) { // can be set from Nginx/Apache fast-cgi conf
+if (getenv('MODBUS_SERIAL_ENABLED')) {
+    // can be set from Nginx/Apache fast-cgi conf
+    // for Nginx add these lines where you PHP is configured:
+    //     fastcgi_param MODBUS_SERIAL_ENABLED true;
+    //     fastcgi_param MODBUS_SERIAL_DEVICE /dev/ttyUSB0;
     $isSerialDevice = filter_var(getenv('MODBUS_SERIAL_ENABLED'), FILTER_VALIDATE_BOOLEAN);
     if ($isSerialDevice && getenv('MODBUS_SERIAL_DEVICE')) {
         $deviceURI = getenv('MODBUS_SERIAL_DEVICE');

--- a/src/Packet/ModbusApplicationHeader.php
+++ b/src/Packet/ModbusApplicationHeader.php
@@ -6,6 +6,7 @@ namespace ModbusTcpClient\Packet;
 
 use ModbusTcpClient\Exception\InvalidArgumentException;
 use ModbusTcpClient\Exception\ModbusException;
+use ModbusTcpClient\Utils\Endian;
 use ModbusTcpClient\Utils\Types;
 
 /**
@@ -100,8 +101,8 @@ class ModbusApplicationHeader
             throw new ModbusException('Data length too short to be valid header!');
         }
 
-        $transactionId = Types::parseUInt16($binaryString[0] . $binaryString[1]);
-        $length = Types::parseUInt16($binaryString[4] . $binaryString[5]);
+        $transactionId = Types::parseUInt16($binaryString[0] . $binaryString[1], Endian::BIG_ENDIAN);
+        $length = Types::parseUInt16($binaryString[4] . $binaryString[5], Endian::BIG_ENDIAN);
         $unitId = Types::parseByte($binaryString[6]);
 
         return new ModbusApplicationHeader(

--- a/src/Packet/ModbusFunction/MaskWriteRegisterRequest.php
+++ b/src/Packet/ModbusFunction/MaskWriteRegisterRequest.php
@@ -93,7 +93,7 @@ class MaskWriteRegisterRequest extends ProtocolDataUnitRequest implements Modbus
      */
     public function getANDMaskAsWord(): Word
     {
-        return new Word(Types::toInt16($this->andMask));
+        return new Word(Types::toInt16($this->andMask, Endian::BIG_ENDIAN));
     }
 
     /**
@@ -101,7 +101,7 @@ class MaskWriteRegisterRequest extends ProtocolDataUnitRequest implements Modbus
      */
     public function getORMaskAsWord(): Word
     {
-        return new Word(Types::toInt16($this->orMask));
+        return new Word(Types::toInt16($this->orMask, Endian::BIG_ENDIAN));
     }
 
     protected function getLengthInternal(): int

--- a/src/Packet/ModbusFunction/MaskWriteRegisterResponse.php
+++ b/src/Packet/ModbusFunction/MaskWriteRegisterResponse.php
@@ -80,7 +80,7 @@ class MaskWriteRegisterResponse extends StartAddressResponse
      */
     public function getANDMaskAsWord(): Word
     {
-        return new Word(Types::toInt16($this->andMask));
+        return new Word(Types::toInt16($this->andMask, Endian::BIG_ENDIAN));
     }
 
     /**
@@ -88,6 +88,6 @@ class MaskWriteRegisterResponse extends StartAddressResponse
      */
     public function getORMaskAsWord(): Word
     {
-        return new Word(Types::toInt16($this->orMask));
+        return new Word(Types::toInt16($this->orMask, Endian::BIG_ENDIAN));
     }
 }

--- a/src/Packet/ProtocolDataUnitRequest.php
+++ b/src/Packet/ProtocolDataUnitRequest.php
@@ -33,7 +33,7 @@ abstract class ProtocolDataUnitRequest extends ProtocolDataUnit
         return b''
             . $this->getHeader()->__toString()
             . Types::toByte($this->getFunctionCode())
-            . Types::toUint16($this->getStartAddress());
+            . Types::toUint16($this->getStartAddress(), Endian::BIG_ENDIAN);
     }
 
     public function getStartAddress(): int

--- a/src/Packet/ResponseFactory.php
+++ b/src/Packet/ResponseFactory.php
@@ -16,6 +16,7 @@ use ModbusTcpClient\Packet\ModbusFunction\WriteMultipleCoilsResponse;
 use ModbusTcpClient\Packet\ModbusFunction\WriteMultipleRegistersResponse;
 use ModbusTcpClient\Packet\ModbusFunction\WriteSingleCoilResponse;
 use ModbusTcpClient\Packet\ModbusFunction\WriteSingleRegisterResponse;
+use ModbusTcpClient\Utils\Endian;
 use ModbusTcpClient\Utils\Types;
 
 class ResponseFactory
@@ -40,7 +41,7 @@ class ResponseFactory
             return new ErrorResponse(ModbusApplicationHeader::parse($binaryString), $functionCode, $exceptionCode);
         }
 
-        $transactionId = Types::parseUInt16($binaryString[0] . $binaryString[1]);
+        $transactionId = Types::parseUInt16($binaryString[0] . $binaryString[1], Endian::BIG_ENDIAN);
         $unitId = Types::parseByte($binaryString[6]);
 
         $rawData = substr($binaryString, 8);

--- a/src/Packet/StartAddressResponse.php
+++ b/src/Packet/StartAddressResponse.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace ModbusTcpClient\Packet;
 
 
+use ModbusTcpClient\Utils\Endian;
 use ModbusTcpClient\Utils\Types;
 
 abstract class StartAddressResponse extends ProtocolDataUnit implements ModbusResponse
@@ -16,7 +17,7 @@ abstract class StartAddressResponse extends ProtocolDataUnit implements ModbusRe
     public function __construct(string $rawData, int $unitId = 0, int $transactionId = null)
     {
         parent::__construct($unitId, $transactionId);
-        $this->startAddress = Types::parseUInt16(substr($rawData, 0, 2));
+        $this->startAddress = Types::parseUInt16(substr($rawData, 0, 2), Endian::BIG_ENDIAN);
     }
 
     public function __toString(): string

--- a/tests/unit/Packet/ModbusFunction/MaskWriteRegisterRequestTest.php
+++ b/tests/unit/Packet/ModbusFunction/MaskWriteRegisterRequestTest.php
@@ -7,11 +7,22 @@ use ModbusTcpClient\Packet\ErrorResponse;
 use ModbusTcpClient\Packet\ModbusFunction\MaskWriteRegisterRequest;
 use ModbusTcpClient\Packet\ModbusPacket;
 use ModbusTcpClient\Packet\Word;
+use ModbusTcpClient\Utils\Endian;
 use ModbusTcpClient\Utils\Types;
 use PHPUnit\Framework\TestCase;
 
 class MaskWriteRegisterRequestTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Endian::$defaultEndian = Endian::LITTLE_ENDIAN; // packets are big endian. setting to default to little should not change output
+    }
+
+    protected function tearDown(): void
+    {
+        Endian::$defaultEndian = Endian::BIG_ENDIAN_LOW_WORD_FIRST;
+    }
+
     public function testOnPacketToString()
     {
         // Field:                    Size in packet

--- a/tests/unit/Packet/ModbusFunction/MaskWriteRegisterResponseTest.php
+++ b/tests/unit/Packet/ModbusFunction/MaskWriteRegisterResponseTest.php
@@ -5,10 +5,21 @@ namespace Tests\Packet\ModbusFunction;
 use ModbusTcpClient\Packet\ModbusFunction\MaskWriteRegisterResponse;
 use ModbusTcpClient\Packet\ModbusPacket;
 use ModbusTcpClient\Packet\Word;
+use ModbusTcpClient\Utils\Endian;
 use PHPUnit\Framework\TestCase;
 
 class MaskWriteRegisterResponseTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Endian::$defaultEndian = Endian::LITTLE_ENDIAN; // packets are big endian. setting to default to little should not change output
+    }
+
+    protected function tearDown(): void
+    {
+        Endian::$defaultEndian = Endian::BIG_ENDIAN_LOW_WORD_FIRST;
+    }
+
     public function testOnPacketToString()
     {
         // Field:                    Size in packet

--- a/tests/unit/Packet/ModbusFunction/ReadCoilsRequestTest.php
+++ b/tests/unit/Packet/ModbusFunction/ReadCoilsRequestTest.php
@@ -6,10 +6,21 @@ use ModbusTcpClient\Exception\InvalidArgumentException;
 use ModbusTcpClient\Packet\ErrorResponse;
 use ModbusTcpClient\Packet\ModbusFunction\ReadCoilsRequest;
 use ModbusTcpClient\Packet\ModbusPacket;
+use ModbusTcpClient\Utils\Endian;
 use PHPUnit\Framework\TestCase;
 
 class ReadCoilsRequestTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Endian::$defaultEndian = Endian::LITTLE_ENDIAN; // packets are big endian. setting to default to little should not change output
+    }
+
+    protected function tearDown(): void
+    {
+        Endian::$defaultEndian = Endian::BIG_ENDIAN_LOW_WORD_FIRST;
+    }
+
     public function testPacketToString()
     {
         $this->assertEquals(

--- a/tests/unit/Packet/ModbusFunction/ReadCoilsResponseTest.php
+++ b/tests/unit/Packet/ModbusFunction/ReadCoilsResponseTest.php
@@ -7,10 +7,21 @@ use ModbusTcpClient\Exception\ModbusException;
 use ModbusTcpClient\Exception\ParseException;
 use ModbusTcpClient\Packet\ModbusFunction\ReadCoilsResponse;
 use ModbusTcpClient\Packet\ModbusPacket;
+use ModbusTcpClient\Utils\Endian;
 use PHPUnit\Framework\TestCase;
 
 class ReadCoilsResponseTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Endian::$defaultEndian = Endian::LITTLE_ENDIAN; // packets are big endian. setting to default to little should not change output
+    }
+
+    protected function tearDown(): void
+    {
+        Endian::$defaultEndian = Endian::BIG_ENDIAN_LOW_WORD_FIRST;
+    }
+
     public function testPacketToString()
     {
         $this->assertEquals(
@@ -18,6 +29,7 @@ class ReadCoilsResponseTest extends TestCase
             (new ReadCoilsResponse("\x02\xCD\x6B", 3, 33152))->__toString()
         );
     }
+
     public function testToHex()
     {
         $this->assertEquals(

--- a/tests/unit/Packet/ModbusFunction/ReadHoldingRegistersRequestTest.php
+++ b/tests/unit/Packet/ModbusFunction/ReadHoldingRegistersRequestTest.php
@@ -6,6 +6,7 @@ use ModbusTcpClient\Exception\InvalidArgumentException;
 use ModbusTcpClient\Packet\ErrorResponse;
 use ModbusTcpClient\Packet\ModbusFunction\ReadHoldingRegistersRequest;
 use ModbusTcpClient\Packet\ModbusPacket;
+use ModbusTcpClient\Utils\Endian;
 use PHPUnit\Framework\TestCase;
 
 /*
@@ -25,6 +26,16 @@ use PHPUnit\Framework\TestCase;
 
 class ReadHoldingRegistersRequestTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Endian::$defaultEndian = Endian::LITTLE_ENDIAN; // packets are big endian. setting to default to little should not change output
+    }
+
+    protected function tearDown(): void
+    {
+        Endian::$defaultEndian = Endian::BIG_ENDIAN_LOW_WORD_FIRST;
+    }
+
     public function testPacketToString()
     {
         $this->assertEquals(

--- a/tests/unit/Packet/ModbusFunction/ReadHoldingRegistersResponseTest.php
+++ b/tests/unit/Packet/ModbusFunction/ReadHoldingRegistersResponseTest.php
@@ -7,10 +7,21 @@ use ModbusTcpClient\Exception\ModbusException;
 use ModbusTcpClient\Exception\ParseException;
 use ModbusTcpClient\Packet\ModbusFunction\ReadHoldingRegistersResponse;
 use ModbusTcpClient\Packet\ModbusPacket;
+use ModbusTcpClient\Utils\Endian;
 use PHPUnit\Framework\TestCase;
 
 class ReadHoldingRegistersResponseTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Endian::$defaultEndian = Endian::LITTLE_ENDIAN; // packets are big endian. setting to default to little should not change output
+    }
+
+    protected function tearDown(): void
+    {
+        Endian::$defaultEndian = Endian::BIG_ENDIAN_LOW_WORD_FIRST;
+    }
+
     public function testPacketToString()
     {
         $this->assertEquals(
@@ -341,7 +352,7 @@ class ReadHoldingRegistersResponseTest extends TestCase
         $packet = (new ReadHoldingRegistersResponse("\x08\x01\x00\xF8\x53\x65\x72\x00\x6E", 3, 33152))->withStartAddress(50);
         $this->assertCount(4, $packet->getWords());
 
-        $this->assertEquals('Søren', $packet->getAsciiStringAt(51, 5));
+        $this->assertEquals('Søren', $packet->getAsciiStringAt(51, 5, Endian::BIG_ENDIAN_LOW_WORD_FIRST));
     }
 
     public function testGetAsciiStringInvalidAddressLow()

--- a/tests/unit/Packet/ModbusFunction/ReadInputDiscretesRequestTest.php
+++ b/tests/unit/Packet/ModbusFunction/ReadInputDiscretesRequestTest.php
@@ -5,10 +5,21 @@ namespace Tests\Packet\ModbusFunction;
 use ModbusTcpClient\Packet\ErrorResponse;
 use ModbusTcpClient\Packet\ModbusFunction\ReadInputDiscretesRequest;
 use ModbusTcpClient\Packet\ModbusPacket;
+use ModbusTcpClient\Utils\Endian;
 use PHPUnit\Framework\TestCase;
 
 class ReadInputDiscretesRequestTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Endian::$defaultEndian = Endian::LITTLE_ENDIAN; // packets are big endian. setting to default to little should not change output
+    }
+
+    protected function tearDown(): void
+    {
+        Endian::$defaultEndian = Endian::BIG_ENDIAN_LOW_WORD_FIRST;
+    }
+
     public function testPacketToString()
     {
         $this->assertEquals(

--- a/tests/unit/Packet/ModbusFunction/ReadInputDiscretesResponseTest.php
+++ b/tests/unit/Packet/ModbusFunction/ReadInputDiscretesResponseTest.php
@@ -5,10 +5,21 @@ namespace Tests\Packet\ModbusFunction;
 use ModbusTcpClient\Exception\ParseException;
 use ModbusTcpClient\Packet\ModbusFunction\ReadInputDiscretesResponse;
 use ModbusTcpClient\Packet\ModbusPacket;
+use ModbusTcpClient\Utils\Endian;
 use PHPUnit\Framework\TestCase;
 
 class ReadInputDiscretesResponseTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Endian::$defaultEndian = Endian::LITTLE_ENDIAN; // packets are big endian. setting to default to little should not change output
+    }
+
+    protected function tearDown(): void
+    {
+        Endian::$defaultEndian = Endian::BIG_ENDIAN_LOW_WORD_FIRST;
+    }
+
     public function testPacketToString()
     {
         $this->assertEquals(

--- a/tests/unit/Packet/ModbusFunction/ReadInputRegistersRequestTest.php
+++ b/tests/unit/Packet/ModbusFunction/ReadInputRegistersRequestTest.php
@@ -6,10 +6,21 @@ namespace Tests\Packet\ModbusFunction;
 use ModbusTcpClient\Packet\ErrorResponse;
 use ModbusTcpClient\Packet\ModbusFunction\ReadInputRegistersRequest;
 use ModbusTcpClient\Packet\ModbusPacket;
+use ModbusTcpClient\Utils\Endian;
 use PHPUnit\Framework\TestCase;
 
 class ReadInputRegistersRequestTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Endian::$defaultEndian = Endian::LITTLE_ENDIAN; // packets are big endian. setting to default to little should not change output
+    }
+
+    protected function tearDown(): void
+    {
+        Endian::$defaultEndian = Endian::BIG_ENDIAN_LOW_WORD_FIRST;
+    }
+
     public function testPacketToString()
     {
         $this->assertEquals(

--- a/tests/unit/Packet/ModbusFunction/ReadInputRegistersResponseTest.php
+++ b/tests/unit/Packet/ModbusFunction/ReadInputRegistersResponseTest.php
@@ -5,10 +5,21 @@ namespace Tests\Packet\ModbusFunction;
 use ModbusTcpClient\Exception\ParseException;
 use ModbusTcpClient\Packet\ModbusFunction\ReadInputRegistersResponse;
 use ModbusTcpClient\Packet\ModbusPacket;
+use ModbusTcpClient\Utils\Endian;
 use PHPUnit\Framework\TestCase;
 
 class ReadInputRegistersResponseTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Endian::$defaultEndian = Endian::LITTLE_ENDIAN; // packets are big endian. setting to default to little should not change output
+    }
+
+    protected function tearDown(): void
+    {
+        Endian::$defaultEndian = Endian::BIG_ENDIAN_LOW_WORD_FIRST;
+    }
+
     public function testPacketToString()
     {
         $this->assertEquals(

--- a/tests/unit/Packet/ModbusFunction/ReadWriteMultipleRegistersRequestTest.php
+++ b/tests/unit/Packet/ModbusFunction/ReadWriteMultipleRegistersRequestTest.php
@@ -6,11 +6,22 @@ use ModbusTcpClient\Exception\InvalidArgumentException;
 use ModbusTcpClient\Packet\ErrorResponse;
 use ModbusTcpClient\Packet\ModbusFunction\ReadWriteMultipleRegistersRequest;
 use ModbusTcpClient\Packet\ModbusPacket;
+use ModbusTcpClient\Utils\Endian;
 use ModbusTcpClient\Utils\Types;
 use PHPUnit\Framework\TestCase;
 
 class ReadWriteMultipleRegistersRequestTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Endian::$defaultEndian = Endian::LITTLE_ENDIAN; // packets are big endian. setting to default to little should not change output
+    }
+
+    protected function tearDown(): void
+    {
+        Endian::$defaultEndian = Endian::BIG_ENDIAN_LOW_WORD_FIRST;
+    }
+
     public function testOnPacketToString()
     {
         // Field:                    Size in packet
@@ -32,7 +43,7 @@ class ReadWriteMultipleRegistersRequestTest extends TestCase
                 0x0410,
                 1,
                 0x0112,
-                [Types::toByte(200), Types::toInt16(130)],
+                [Types::toByte(200), Types::toInt16(130, Endian::BIG_ENDIAN_LOW_WORD_FIRST)],
                 0x11,
                 0x0138
             ))->__toString()
@@ -176,7 +187,7 @@ class ReadWriteMultipleRegistersRequestTest extends TestCase
             0x0410,
             1,
             0x0112,
-            [Types::toByte(200), Types::toInt16(130)],
+            [Types::toByte(200), Types::toInt16(130, Endian::BIG_ENDIAN_LOW_WORD_FIRST)],
             0x11,
             0x0138
         ))->__toString());

--- a/tests/unit/Packet/ModbusFunction/ReadWriteMultipleRegistersResponseTest.php
+++ b/tests/unit/Packet/ModbusFunction/ReadWriteMultipleRegistersResponseTest.php
@@ -7,10 +7,21 @@ use ModbusTcpClient\Exception\ModbusException;
 use ModbusTcpClient\Exception\ParseException;
 use ModbusTcpClient\Packet\ModbusFunction\ReadWriteMultipleRegistersResponse;
 use ModbusTcpClient\Packet\ModbusPacket;
+use ModbusTcpClient\Utils\Endian;
 use PHPUnit\Framework\TestCase;
 
 class ReadWriteMultipleRegistersResponseTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Endian::$defaultEndian = Endian::LITTLE_ENDIAN; // packets are big endian. setting to default to little should not change output
+    }
+
+    protected function tearDown(): void
+    {
+        Endian::$defaultEndian = Endian::BIG_ENDIAN_LOW_WORD_FIRST;
+    }
+
     public function testPacketToString()
     {
         $this->assertEquals(
@@ -341,7 +352,7 @@ class ReadWriteMultipleRegistersResponseTest extends TestCase
         $packet = (new ReadWriteMultipleRegistersResponse("\x08\x01\x00\xF8\x53\x65\x72\x00\x6E", 3, 33152))->withStartAddress(50);
         $this->assertCount(4, $packet->getWords());
 
-        $this->assertEquals('Søren', $packet->getAsciiStringAt(51, 5));
+        $this->assertEquals('Søren', $packet->getAsciiStringAt(51, 5, Endian::BIG_ENDIAN_LOW_WORD_FIRST));
     }
 
     public function testGetAsciiStringInvalidAddressLow()

--- a/tests/unit/Packet/ModbusFunction/WriteMultipleCoilsRequestTest.php
+++ b/tests/unit/Packet/ModbusFunction/WriteMultipleCoilsRequestTest.php
@@ -6,10 +6,21 @@ use ModbusTcpClient\Exception\InvalidArgumentException;
 use ModbusTcpClient\Packet\ErrorResponse;
 use ModbusTcpClient\Packet\ModbusFunction\WriteMultipleCoilsRequest;
 use ModbusTcpClient\Packet\ModbusPacket;
+use ModbusTcpClient\Utils\Endian;
 use PHPUnit\Framework\TestCase;
 
 class WriteMultipleCoilsRequestTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Endian::$defaultEndian = Endian::LITTLE_ENDIAN; // packets are big endian. setting to default to little should not change output
+    }
+
+    protected function tearDown(): void
+    {
+        Endian::$defaultEndian = Endian::BIG_ENDIAN_LOW_WORD_FIRST;
+    }
+
     public function testOnPacketToString()
     {
         $this->assertEquals(

--- a/tests/unit/Packet/ModbusFunction/WriteMultipleCoilsResponseTest.php
+++ b/tests/unit/Packet/ModbusFunction/WriteMultipleCoilsResponseTest.php
@@ -3,12 +3,23 @@
 namespace Tests\Packet\ModbusFunction;
 
 
-use ModbusTcpClient\Packet\ModbusPacket;
 use ModbusTcpClient\Packet\ModbusFunction\WriteMultipleCoilsResponse;
+use ModbusTcpClient\Packet\ModbusPacket;
+use ModbusTcpClient\Utils\Endian;
 use PHPUnit\Framework\TestCase;
 
 class WriteMultipleCoilsResponseTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Endian::$defaultEndian = Endian::LITTLE_ENDIAN; // packets are big endian. setting to default to little should not change output
+    }
+
+    protected function tearDown(): void
+    {
+        Endian::$defaultEndian = Endian::BIG_ENDIAN_LOW_WORD_FIRST;
+    }
+
     public function testOnPacketToString()
     {
         $this->assertEquals(

--- a/tests/unit/Packet/ModbusFunction/WriteMultipleRegistersResponseTest.php
+++ b/tests/unit/Packet/ModbusFunction/WriteMultipleRegistersResponseTest.php
@@ -3,12 +3,23 @@
 namespace Tests\Packet\ModbusFunction;
 
 
-use ModbusTcpClient\Packet\ModbusPacket;
 use ModbusTcpClient\Packet\ModbusFunction\WriteMultipleRegistersResponse;
+use ModbusTcpClient\Packet\ModbusPacket;
+use ModbusTcpClient\Utils\Endian;
 use PHPUnit\Framework\TestCase;
 
 class WriteMultipleRegistersResponseTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Endian::$defaultEndian = Endian::LITTLE_ENDIAN; // packets are big endian. setting to default to little should not change output
+    }
+
+    protected function tearDown(): void
+    {
+        Endian::$defaultEndian = Endian::BIG_ENDIAN_LOW_WORD_FIRST;
+    }
+
     public function testOnPacketToString()
     {
         $this->assertEquals(

--- a/tests/unit/Packet/ModbusFunction/WriteSingleCoilRequestTest.php
+++ b/tests/unit/Packet/ModbusFunction/WriteSingleCoilRequestTest.php
@@ -5,10 +5,21 @@ namespace Tests\Packet\ModbusFunction;
 use ModbusTcpClient\Packet\ErrorResponse;
 use ModbusTcpClient\Packet\ModbusFunction\WriteSingleCoilRequest;
 use ModbusTcpClient\Packet\ModbusPacket;
+use ModbusTcpClient\Utils\Endian;
 use PHPUnit\Framework\TestCase;
 
 class WriteSingleCoilRequestTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Endian::$defaultEndian = Endian::LITTLE_ENDIAN; // packets are big endian. setting to default to little should not change output
+    }
+
+    protected function tearDown(): void
+    {
+        Endian::$defaultEndian = Endian::BIG_ENDIAN_LOW_WORD_FIRST;
+    }
+
     public function testOnPacketToString()
     {
         $this->assertEquals(

--- a/tests/unit/Packet/ModbusFunction/WriteSingleCoilResponseTest.php
+++ b/tests/unit/Packet/ModbusFunction/WriteSingleCoilResponseTest.php
@@ -1,13 +1,25 @@
 <?php
+
 namespace Tests\Packet\ModbusFunction;
 
 
-use ModbusTcpClient\Packet\ModbusPacket;
 use ModbusTcpClient\Packet\ModbusFunction\WriteSingleCoilResponse;
+use ModbusTcpClient\Packet\ModbusPacket;
+use ModbusTcpClient\Utils\Endian;
 use PHPUnit\Framework\TestCase;
 
 class WriteSingleCoilResponseTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Endian::$defaultEndian = Endian::LITTLE_ENDIAN; // packets are big endian. setting to default to little should not change output
+    }
+
+    protected function tearDown(): void
+    {
+        Endian::$defaultEndian = Endian::BIG_ENDIAN_LOW_WORD_FIRST;
+    }
+
     public function testPacketToString()
     {
         $this->assertEquals(

--- a/tests/unit/Packet/ModbusFunction/WriteSingleRegisterRequestTest.php
+++ b/tests/unit/Packet/ModbusFunction/WriteSingleRegisterRequestTest.php
@@ -6,10 +6,21 @@ use ModbusTcpClient\Exception\InvalidArgumentException;
 use ModbusTcpClient\Packet\ErrorResponse;
 use ModbusTcpClient\Packet\ModbusFunction\WriteSingleRegisterRequest;
 use ModbusTcpClient\Packet\ModbusPacket;
+use ModbusTcpClient\Utils\Endian;
 use PHPUnit\Framework\TestCase;
 
 class WriteSingleRegisterRequestTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Endian::$defaultEndian = Endian::LITTLE_ENDIAN; // packets are big endian. setting to default to little should not change output
+    }
+
+    protected function tearDown(): void
+    {
+        Endian::$defaultEndian = Endian::BIG_ENDIAN_LOW_WORD_FIRST;
+    }
+
     public function testPacketToString()
     {
         $this->assertEquals(

--- a/tests/unit/Packet/ModbusFunction/WriteSingleRegisterResponseTest.php
+++ b/tests/unit/Packet/ModbusFunction/WriteSingleRegisterResponseTest.php
@@ -5,10 +5,21 @@ namespace Tests\Packet\ModbusFunction;
 
 use ModbusTcpClient\Packet\ModbusFunction\WriteSingleRegisterResponse;
 use ModbusTcpClient\Packet\ModbusPacket;
+use ModbusTcpClient\Utils\Endian;
 use PHPUnit\Framework\TestCase;
 
 class WriteSingleRegisterResponseTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Endian::$defaultEndian = Endian::LITTLE_ENDIAN; // packets are big endian. setting to default to little should not change output
+    }
+
+    protected function tearDown(): void
+    {
+        Endian::$defaultEndian = Endian::BIG_ENDIAN_LOW_WORD_FIRST;
+    }
+
     public function testPacketToString()
     {
         $this->assertEquals(
@@ -22,7 +33,7 @@ class WriteSingleRegisterResponseTest extends TestCase
         $packet = new WriteSingleRegisterResponse("\x00\x02\xFF\x00", 3, 33152);
         $this->assertEquals(ModbusPacket::WRITE_SINGLE_REGISTER, $packet->getFunctionCode());
 
-        $this->assertEquals(0xFF00, $packet->getWord()->getUInt16());
+        $this->assertEquals(0xFF00, $packet->getWord()->getUInt16(Endian::BIG_ENDIAN_LOW_WORD_FIRST));
 
         $header = $packet->getHeader();
         $this->assertEquals(33152, $header->getTransactionId());


### PR DESCRIPTION
when `Endian::$defaultEndian = Endian::LITTLE_ENDIAN;` is done before request is created/parsed the result will be wrong as  packets are always BIG_ENDIAN but changing global endian makes different things to be parsed incorrectly