### PR TITLE
Allow unit ID to be in range of 0-255.

### DIFF
--- a/examples/fc1.php
+++ b/examples/fc1.php
@@ -16,7 +16,7 @@ $connection = BinaryStreamConnection::getBuilder()
 
 $startAddress = 12288;
 $quantity = 16;
-$unitID = 0;
+$unitID = 1;
 $packet = new ReadCoilsRequest($startAddress, $quantity, $unitID); // NB: This is Modbus TCP packet not Modbus RTU over TCP!
 echo 'Packet to be sent (in hex): ' . $packet->toHex() . PHP_EOL;
 

--- a/examples/fc15.php
+++ b/examples/fc15.php
@@ -20,7 +20,7 @@ $coils = [
     0, 0, 0, 0, 0, 0, 0, 0, // dec: 0, hex x0
     1, 0, 0, 1 // dec: 9, hex: x9
 ];
-$unitID = 0;
+$unitID = 1;
 $packet = new WriteMultipleCoilsRequest($startAddress, $coils, $unitID); // NB: This is Modbus TCP packet not Modbus RTU over TCP!
 echo 'Packet to be sent (in hex): ' . $packet->toHex() . PHP_EOL;
 

--- a/examples/fc16.php
+++ b/examples/fc16.php
@@ -22,7 +22,7 @@ $registers = [
     Types::toInt16(-1000), //hex: FC18 as word
     Types::toInt32(2000), //dec: 2000 -> hex: 7d00 is as 2 word 7D00 0000
 ];
-$unitID = 0;
+$unitID = 1;
 $packet = new WriteMultipleRegistersRequest($startAddress, $registers, $unitID); // NB: This is Modbus TCP packet not Modbus RTU over TCP!
 echo 'Packet to be sent (in hex): ' . $packet->toHex() . PHP_EOL;
 

--- a/examples/fc2.php
+++ b/examples/fc2.php
@@ -16,7 +16,7 @@ $connection = BinaryStreamConnection::getBuilder()
 
 $startAddress = 12288;
 $quantity = 16;
-$unitID = 0;
+$unitID = 1;
 $packet = new ReadInputDiscretesRequest($startAddress, $quantity, $unitID); // NB: This is Modbus TCP packet not Modbus RTU over TCP!
 echo 'Packet to be sent (in hex): ' . $packet->toHex() . PHP_EOL;
 

--- a/examples/fc22.php
+++ b/examples/fc22.php
@@ -23,7 +23,7 @@ $ANDMask |= (1 << $bitPosition); // set the bit, set third bit to 1. $ANDMask = 
 $ORMask = 0x0007; // 2 bytes, bin = 0b00000111
 $ORMask &= ~(1 << $bitPosition); // clear the bit, set third bit to 0. $ORMask = 0x0003, 0b00000011
 
-$unitID = 0;
+$unitID = 1;
 $packet = new MaskWriteRegisterRequest(
     $readStartAddress,
     $ANDMask,

--- a/examples/fc23.php
+++ b/examples/fc23.php
@@ -23,7 +23,7 @@ $writeRegisters = [
     Types::toInt16(10), //000a as word
     Types::toInt16(-1000), //hex: FC18 as word
 ];
-$unitID = 0;
+$unitID = 1;
 $packet = new ReadWriteMultipleRegistersRequest(
     $readStartAddress,
     $readQuantity,

--- a/examples/fc3.php
+++ b/examples/fc3.php
@@ -22,7 +22,7 @@ $connection = BinaryStreamConnection::getBuilder()
 
 $startAddress = 256;
 $quantity = 6;
-$unitID = 0;
+$unitID = 1;
 $packet = new ReadHoldingRegistersRequest($startAddress, $quantity, $unitID); // NB: This is Modbus TCP packet not Modbus RTU over TCP!
 
 try {

--- a/examples/fc4.php
+++ b/examples/fc4.php
@@ -16,7 +16,7 @@ $connection = BinaryStreamConnection::getBuilder()
 
 $startAddress = 256;
 $quantity = 6;
-$unitID = 0;
+$unitID = 1;
 $packet = new ReadInputRegistersRequest($startAddress, $quantity, $unitID); // NB: This is Modbus TCP packet not Modbus RTU over TCP!
 echo 'Packet to be sent (in hex): ' . $packet->toHex() . PHP_EOL;
 

--- a/examples/fc5.php
+++ b/examples/fc5.php
@@ -16,7 +16,7 @@ $connection = BinaryStreamConnection::getBuilder()
 
 $startAddress = 12288;
 $coil = true;
-$unitID = 0;
+$unitID = 1;
 $packet = new WriteSingleCoilRequest($startAddress, $coil, $unitID); // NB: This is Modbus TCP packet not Modbus RTU over TCP!
 echo 'Packet to be sent (in hex): ' . $packet->toHex() . PHP_EOL;
 

--- a/examples/fc6.php
+++ b/examples/fc6.php
@@ -16,7 +16,7 @@ $connection = BinaryStreamConnection::getBuilder()
 
 $startAddress = 12288;
 $value = 55;
-$unitID = 0;
+$unitID = 1;
 $packet = new WriteSingleRegisterRequest($startAddress, $value, $unitID); // NB: This is Modbus TCP packet not Modbus RTU over TCP!
 echo 'Packet to be sent (in hex): ' . $packet->toHex() . PHP_EOL;
 

--- a/src/Packet/ModbusApplicationHeader.php
+++ b/src/Packet/ModbusApplicationHeader.php
@@ -117,8 +117,12 @@ class ModbusApplicationHeader
         if (!$length || !($length > 0 && $length <= Types::MAX_VALUE_UINT16)) {
             throw new InvalidArgumentException("length is not set or out of range (uint16): {$length}");
         }
-        if (!($unitId >= 0 && $unitId <= 247)) {
-            throw new InvalidArgumentException("unitId is out of range (0-247): {$unitId}");
+        if (!($unitId >= 0 && $unitId <= 255)) {
+            // Older MODBUS specification limited unit ID (slave id) in range of 0-247)
+            // See "Modicon Modbus Protocol Reference Guide PI–MBUS–300 Rev. J" page 19
+            //
+            // but newer spec has that limitation removed.
+            throw new InvalidArgumentException("unitId is out of range (0-255): {$unitId}");
         }
         if ((null !== $transactionId) && !($transactionId >= 0 && $transactionId <= Types::MAX_VALUE_UINT16)) {
             throw new InvalidArgumentException("transactionId is out of range (uint16): {$transactionId}");

--- a/tests/unit/Packet/ModbusApplicationHeaderTest.php
+++ b/tests/unit/Packet/ModbusApplicationHeaderTest.php
@@ -82,15 +82,15 @@ class ModbusApplicationHeaderTest extends TestCase
 
     public function testUnitIdOverFlow()
     {
-        $this->expectExceptionMessage("unitId is out of range (0-247): 248");
+        $this->expectExceptionMessage("unitId is out of range (0-255): 256");
         $this->expectException(InvalidArgumentException::class);
 
-        new ModbusApplicationHeader(1, 248, 1);
+        new ModbusApplicationHeader(1, 256, 1);
     }
 
     public function testUnitIdUnderFlow()
     {
-        $this->expectExceptionMessage("unitId is out of range (0-247): -1");
+        $this->expectExceptionMessage("unitId is out of range (0-255): -1");
         $this->expectException(InvalidArgumentException::class);
 
         new ModbusApplicationHeader(1, -1, 1);

--- a/tests/unit/Packet/ProtocolDataUnitTest.php
+++ b/tests/unit/Packet/ProtocolDataUnitTest.php
@@ -22,7 +22,7 @@ class ProtocolDataUnitTest extends TestCase
 
     public function testFailWithNegativeUnitID()
     {
-        $this->expectExceptionMessage("unitId is out of range (0-247): -1");
+        $this->expectExceptionMessage("unitId is out of range (0-255): -1");
         $this->expectException(InvalidArgumentException::class);
 
         new ProtocolDataUnitImpl(-1);

--- a/tests/unit/Utils/TypesTest.php
+++ b/tests/unit/Utils/TypesTest.php
@@ -340,7 +340,7 @@ class TypesTest extends TestCase
 
     public function testShouldExceptionWhenBitToHighNumber()
     {
-        $this->expectErrorMessageMatches("/On .*bit PHP bit shifting more than .* bit is not possible as int size is .* bytes/");
+        $this->expectExceptionMessageMatches("/On .*bit PHP bit shifting more than .* bit is not possible as int size is .* bytes/");
         $this->expectException(InvalidArgumentException::class);
 
         if (PHP_INT_SIZE === 4) {


### PR DESCRIPTION
Older MODBUS specification limited unit ID (slave id) in range of 0-247).  See "Modicon Modbus Protocol Reference Guide PI–MBUS–300 Rev. J" page 19. https://modbus.org/docs/PI_MBUS_300.pdf

In newer spec that limitation is removed.

Fixes #159