### PR TITLE
Cs fixer 8 4

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -15,10 +15,11 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-version: ['8.0', '8.1', '8.2', '8.3']
+        # See https://www.php.net/supported-versions.php
+        php-version: ['8.1', '8.2', '8.3', '8.4']
     name: PHP ${{ matrix.php-version }} Test on ${{ matrix.operating-system }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
@@ -41,8 +42,8 @@ jobs:
       run: composer test-ci
 
     - name: Upload coverage to Codecov
-      if: matrix.php-version == '8.3' &&  matrix.operating-system == 'ubuntu-latest'
-      uses: codecov/codecov-action@v3
+      if: matrix.php-version == '8.4' &&  matrix.operating-system == 'ubuntu-latest'
+      uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./report/coverage.xml

--- a/composer.lock
+++ b/composer.lock
@@ -126,16 +126,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.11.1",
+            "version": "1.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c"
+                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
-                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/123267b2c49fbf30d78a7b2d333f6be754b94845",
+                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845",
                 "shasum": ""
             },
             "require": {
@@ -143,11 +143,12 @@
             },
             "conflict": {
                 "doctrine/collections": "<1.6.8",
-                "doctrine/common": "<2.13.3 || >=3,<3.2.2"
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
             },
             "require-dev": {
                 "doctrine/collections": "^1.6.8",
                 "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
                 "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
             },
             "type": "library",
@@ -173,7 +174,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.1"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.1"
             },
             "funding": [
                 {
@@ -181,29 +182,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-08T13:26:56+00:00"
+            "time": "2024-11-08T17:47:46+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.18.0",
+            "version": "v5.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "1bcbb2179f97633e98bbbc87044ee2611c7d7999"
+                "reference": "8eea230464783aa9671db8eea6f8c6ac5285794b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/1bcbb2179f97633e98bbbc87044ee2611c7d7999",
-                "reference": "1bcbb2179f97633e98bbbc87044ee2611c7d7999",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/8eea230464783aa9671db8eea6f8c6ac5285794b",
+                "reference": "8eea230464783aa9671db8eea6f8c6ac5285794b",
                 "shasum": ""
             },
             "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
                 "ext-tokenizer": "*",
-                "php": ">=7.0"
+                "php": ">=7.4"
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^9.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -211,7 +214,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.9-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -235,26 +238,27 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.18.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.3.1"
             },
-            "time": "2023-12-10T21:03:43+00:00"
+            "time": "2024-10-08T18:51:32+00:00"
         },
         {
             "name": "phar-io/manifest",
-            "version": "2.0.3",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
-                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-libxml": "*",
                 "ext-phar": "*",
                 "ext-xmlwriter": "*",
                 "phar-io/version": "^3.0.1",
@@ -295,9 +299,15 @@
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
             "support": {
                 "issues": "https://github.com/phar-io/manifest/issues",
-                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
             },
-            "time": "2021-07-20T11:28:43+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
         },
         {
             "name": "phar-io/version",
@@ -352,16 +362,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.50",
+            "version": "1.12.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "06a98513ac72c03e8366b5a0cb00750b487032e4"
+                "reference": "0d1fc20a962a91be578bcfe7cf939e6e1a2ff733"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/06a98513ac72c03e8366b5a0cb00750b487032e4",
-                "reference": "06a98513ac72c03e8366b5a0cb00750b487032e4",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/0d1fc20a962a91be578bcfe7cf939e6e1a2ff733",
+                "reference": "0d1fc20a962a91be578bcfe7cf939e6e1a2ff733",
                 "shasum": ""
             },
             "require": {
@@ -404,45 +414,41 @@
                 {
                     "url": "https://github.com/phpstan",
                     "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2023-12-13T10:59:42+00:00"
+            "time": "2024-11-17T14:08:01+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.30",
+            "version": "9.2.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "ca2bd87d2f9215904682a9cb9bb37dda98e76089"
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ca2bd87d2f9215904682a9cb9bb37dda98e76089",
-                "reference": "ca2bd87d2f9215904682a9cb9bb37dda98e76089",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.18 || ^5.0",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
                 "php": ">=7.3",
-                "phpunit/php-file-iterator": "^3.0.3",
-                "phpunit/php-text-template": "^2.0.2",
-                "sebastian/code-unit-reverse-lookup": "^2.0.2",
-                "sebastian/complexity": "^2.0",
-                "sebastian/environment": "^5.1.2",
-                "sebastian/lines-of-code": "^1.0.3",
-                "sebastian/version": "^3.0.1",
-                "theseer/tokenizer": "^1.2.0"
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "sebastian/code-unit-reverse-lookup": "^2.0.3",
+                "sebastian/complexity": "^2.0.3",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/lines-of-code": "^1.0.4",
+                "sebastian/version": "^3.0.2",
+                "theseer/tokenizer": "^1.2.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^9.6"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -451,7 +457,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.2-dev"
+                    "dev-main": "9.2.x-dev"
                 }
             },
             "autoload": {
@@ -480,7 +486,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.30"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
             },
             "funding": [
                 {
@@ -488,7 +494,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-22T06:47:57+00:00"
+            "time": "2024-08-22T04:23:01+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -733,45 +739,45 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.15",
+            "version": "9.6.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "05017b80304e0eb3f31d90194a563fd53a6021f1"
+                "reference": "de6abf3b6f8dd955fac3caad3af7a9504e8c2ffa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/05017b80304e0eb3f31d90194a563fd53a6021f1",
-                "reference": "05017b80304e0eb3f31d90194a563fd53a6021f1",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/de6abf3b6f8dd955fac3caad3af7a9504e8c2ffa",
+                "reference": "de6abf3b6f8dd955fac3caad3af7a9504e8c2ffa",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.3.1 || ^2",
+                "doctrine/instantiator": "^1.5.0 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.10.1",
-                "phar-io/manifest": "^2.0.3",
-                "phar-io/version": "^3.0.2",
+                "myclabs/deep-copy": "^1.12.0",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
                 "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.28",
-                "phpunit/php-file-iterator": "^3.0.5",
+                "phpunit/php-code-coverage": "^9.2.32",
+                "phpunit/php-file-iterator": "^3.0.6",
                 "phpunit/php-invoker": "^3.1.1",
-                "phpunit/php-text-template": "^2.0.3",
-                "phpunit/php-timer": "^5.0.2",
-                "sebastian/cli-parser": "^1.0.1",
-                "sebastian/code-unit": "^1.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "phpunit/php-timer": "^5.0.3",
+                "sebastian/cli-parser": "^1.0.2",
+                "sebastian/code-unit": "^1.0.8",
                 "sebastian/comparator": "^4.0.8",
-                "sebastian/diff": "^4.0.3",
-                "sebastian/environment": "^5.1.3",
-                "sebastian/exporter": "^4.0.5",
-                "sebastian/global-state": "^5.0.1",
-                "sebastian/object-enumerator": "^4.0.3",
-                "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^3.2",
+                "sebastian/diff": "^4.0.6",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/exporter": "^4.0.6",
+                "sebastian/global-state": "^5.0.7",
+                "sebastian/object-enumerator": "^4.0.4",
+                "sebastian/resource-operations": "^3.0.4",
+                "sebastian/type": "^3.2.1",
                 "sebastian/version": "^3.0.2"
             },
             "suggest": {
@@ -816,7 +822,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.15"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.21"
             },
             "funding": [
                 {
@@ -832,7 +838,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-01T16:55:19+00:00"
+            "time": "2024-09-19T10:50:18+00:00"
         },
         {
             "name": "psr/log",
@@ -1037,28 +1043,28 @@
         },
         {
             "name": "react/datagram",
-            "version": "v1.9.0",
+            "version": "v1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/datagram.git",
-                "reference": "13c259bb2fd04f238eeb85f3783167eedec46e2c"
+                "reference": "9236e1f5a67a6029be17d551e9858c487836c301"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/datagram/zipball/13c259bb2fd04f238eeb85f3783167eedec46e2c",
-                "reference": "13c259bb2fd04f238eeb85f3783167eedec46e2c",
+                "url": "https://api.github.com/repos/reactphp/datagram/zipball/9236e1f5a67a6029be17d551e9858c487836c301",
+                "reference": "9236e1f5a67a6029be17d551e9858c487836c301",
                 "shasum": ""
             },
             "require": {
                 "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
                 "php": ">=5.3",
-                "react/dns": "^1.7",
+                "react/dns": "^1.13",
                 "react/event-loop": "^1.2",
-                "react/promise": "^3 || ^2.1 || ^1.2"
+                "react/promise": "^3.2 || ^2.1 || ^1.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.35",
-                "react/async": "^4 || ^3 || ^2"
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+                "react/async": "^4.3 || ^3 || ^2"
             },
             "type": "library",
             "autoload": {
@@ -1106,7 +1112,7 @@
             ],
             "support": {
                 "issues": "https://github.com/reactphp/datagram/issues",
-                "source": "https://github.com/reactphp/datagram/tree/v1.9.0"
+                "source": "https://github.com/reactphp/datagram/tree/v1.10.0"
             },
             "funding": [
                 {
@@ -1114,32 +1120,32 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2022-12-05T13:45:40+00:00"
+            "time": "2024-09-06T11:22:35+00:00"
         },
         {
             "name": "react/dns",
-            "version": "v1.12.0",
+            "version": "v1.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/dns.git",
-                "reference": "c134600642fa615b46b41237ef243daa65bb64ec"
+                "reference": "eb8ae001b5a455665c89c1df97f6fb682f8fb0f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/dns/zipball/c134600642fa615b46b41237ef243daa65bb64ec",
-                "reference": "c134600642fa615b46b41237ef243daa65bb64ec",
+                "url": "https://api.github.com/repos/reactphp/dns/zipball/eb8ae001b5a455665c89c1df97f6fb682f8fb0f5",
+                "reference": "eb8ae001b5a455665c89c1df97f6fb682f8fb0f5",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.0",
                 "react/cache": "^1.0 || ^0.6 || ^0.5",
                 "react/event-loop": "^1.2",
-                "react/promise": "^3.0 || ^2.7 || ^1.2.1"
+                "react/promise": "^3.2 || ^2.7 || ^1.2.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
-                "react/async": "^4 || ^3 || ^2",
-                "react/promise-timer": "^1.9"
+                "react/async": "^4.3 || ^3 || ^2",
+                "react/promise-timer": "^1.11"
             },
             "type": "library",
             "autoload": {
@@ -1182,7 +1188,7 @@
             ],
             "support": {
                 "issues": "https://github.com/reactphp/dns/issues",
-                "source": "https://github.com/reactphp/dns/tree/v1.12.0"
+                "source": "https://github.com/reactphp/dns/tree/v1.13.0"
             },
             "funding": [
                 {
@@ -1190,7 +1196,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2023-11-29T12:41:06+00:00"
+            "time": "2024-06-13T14:18:03+00:00"
         },
         {
             "name": "react/event-loop",
@@ -1266,16 +1272,16 @@
         },
         {
             "name": "react/promise",
-            "version": "v3.1.0",
+            "version": "v3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/promise.git",
-                "reference": "e563d55d1641de1dea9f5e84f3cccc66d2bfe02c"
+                "reference": "8a164643313c71354582dc850b42b33fa12a4b63"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/promise/zipball/e563d55d1641de1dea9f5e84f3cccc66d2bfe02c",
-                "reference": "e563d55d1641de1dea9f5e84f3cccc66d2bfe02c",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/8a164643313c71354582dc850b42b33fa12a4b63",
+                "reference": "8a164643313c71354582dc850b42b33fa12a4b63",
                 "shasum": ""
             },
             "require": {
@@ -1327,7 +1333,7 @@
             ],
             "support": {
                 "issues": "https://github.com/reactphp/promise/issues",
-                "source": "https://github.com/reactphp/promise/tree/v3.1.0"
+                "source": "https://github.com/reactphp/promise/tree/v3.2.0"
             },
             "funding": [
                 {
@@ -1335,35 +1341,35 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2023-11-16T16:21:57+00:00"
+            "time": "2024-05-24T10:39:05+00:00"
         },
         {
             "name": "react/socket",
-            "version": "v1.15.0",
+            "version": "v1.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/socket.git",
-                "reference": "216d3aec0b87f04a40ca04f481e6af01bdd1d038"
+                "reference": "23e4ff33ea3e160d2d1f59a0e6050e4b0fb0eac1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/socket/zipball/216d3aec0b87f04a40ca04f481e6af01bdd1d038",
-                "reference": "216d3aec0b87f04a40ca04f481e6af01bdd1d038",
+                "url": "https://api.github.com/repos/reactphp/socket/zipball/23e4ff33ea3e160d2d1f59a0e6050e4b0fb0eac1",
+                "reference": "23e4ff33ea3e160d2d1f59a0e6050e4b0fb0eac1",
                 "shasum": ""
             },
             "require": {
                 "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
                 "php": ">=5.3.0",
-                "react/dns": "^1.11",
+                "react/dns": "^1.13",
                 "react/event-loop": "^1.2",
-                "react/promise": "^3 || ^2.6 || ^1.2.1",
-                "react/stream": "^1.2"
+                "react/promise": "^3.2 || ^2.6 || ^1.2.1",
+                "react/stream": "^1.4"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
-                "react/async": "^4 || ^3 || ^2",
+                "react/async": "^4.3 || ^3.3 || ^2",
                 "react/promise-stream": "^1.4",
-                "react/promise-timer": "^1.10"
+                "react/promise-timer": "^1.11"
             },
             "type": "library",
             "autoload": {
@@ -1407,7 +1413,7 @@
             ],
             "support": {
                 "issues": "https://github.com/reactphp/socket/issues",
-                "source": "https://github.com/reactphp/socket/tree/v1.15.0"
+                "source": "https://github.com/reactphp/socket/tree/v1.16.0"
             },
             "funding": [
                 {
@@ -1415,20 +1421,20 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2023-12-15T11:02:10+00:00"
+            "time": "2024-07-26T10:38:09+00:00"
         },
         {
             "name": "react/stream",
-            "version": "v1.3.0",
+            "version": "v1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/stream.git",
-                "reference": "6fbc9672905c7d5a885f2da2fc696f65840f4a66"
+                "reference": "1e5b0acb8fe55143b5b426817155190eb6f5b18d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/stream/zipball/6fbc9672905c7d5a885f2da2fc696f65840f4a66",
-                "reference": "6fbc9672905c7d5a885f2da2fc696f65840f4a66",
+                "url": "https://api.github.com/repos/reactphp/stream/zipball/1e5b0acb8fe55143b5b426817155190eb6f5b18d",
+                "reference": "1e5b0acb8fe55143b5b426817155190eb6f5b18d",
                 "shasum": ""
             },
             "require": {
@@ -1438,7 +1444,7 @@
             },
             "require-dev": {
                 "clue/stream-filter": "~1.2",
-                "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.35"
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
             },
             "type": "library",
             "autoload": {
@@ -1485,7 +1491,7 @@
             ],
             "support": {
                 "issues": "https://github.com/reactphp/stream/issues",
-                "source": "https://github.com/reactphp/stream/tree/v1.3.0"
+                "source": "https://github.com/reactphp/stream/tree/v1.4.0"
             },
             "funding": [
                 {
@@ -1493,20 +1499,20 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2023-06-16T10:52:11+00:00"
+            "time": "2024-06-11T12:45:25+00:00"
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
                 "shasum": ""
             },
             "require": {
@@ -1541,7 +1547,7 @@
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
             },
             "funding": [
                 {
@@ -1549,7 +1555,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:08:49+00:00"
+            "time": "2024-03-02T06:27:43+00:00"
         },
         {
             "name": "sebastian/code-unit",
@@ -1795,16 +1801,16 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.5",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131"
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
-                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
                 "shasum": ""
             },
             "require": {
@@ -1849,7 +1855,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
             },
             "funding": [
                 {
@@ -1857,7 +1863,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-05-07T05:35:17+00:00"
+            "time": "2024-03-02T06:30:58+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -1924,16 +1930,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.5",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d"
+                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
-                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/78c00df8f170e02473b682df15bfcdacc3d32d72",
+                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72",
                 "shasum": ""
             },
             "require": {
@@ -1989,7 +1995,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.6"
             },
             "funding": [
                 {
@@ -1997,20 +2003,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-14T06:03:37+00:00"
+            "time": "2024-03-02T06:33:00+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.6",
+            "version": "5.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bde739e7565280bda77be70044ac1047bc007e34"
+                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bde739e7565280bda77be70044ac1047bc007e34",
-                "reference": "bde739e7565280bda77be70044ac1047bc007e34",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
+                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
                 "shasum": ""
             },
             "require": {
@@ -2053,7 +2059,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.6"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.7"
             },
             "funding": [
                 {
@@ -2061,7 +2067,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-08-02T09:26:13+00:00"
+            "time": "2024-03-02T06:35:11+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -2297,16 +2303,16 @@
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "3.0.3",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
                 "shasum": ""
             },
             "require": {
@@ -2318,7 +2324,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2339,8 +2345,7 @@
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
             "support": {
-                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
             },
             "funding": [
                 {
@@ -2348,7 +2353,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:45:17+00:00"
+            "time": "2024-03-14T16:00:52+00:00"
         },
         {
             "name": "sebastian/type",
@@ -2461,16 +2466,16 @@
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.2",
+            "version": "1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96"
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
-                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
                 "shasum": ""
             },
             "require": {
@@ -2499,7 +2504,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.2"
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.3"
             },
             "funding": [
                 {
@@ -2507,7 +2512,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-11-20T00:12:19+00:00"
+            "time": "2024-03-03T12:36:25+00:00"
         }
     ],
     "aliases": [],

--- a/src/Composer/Address.php
+++ b/src/Composer/Address.php
@@ -1,24 +1,24 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Composer;
 
-
 interface Address
 {
-    const TYPE_BIT = 'bit';
-    const TYPE_BYTE = 'byte';
-    const TYPE_INT16 = 'int16';
-    const TYPE_UINT16 = 'uint16';
-    const TYPE_INT32 = 'int32';
-    const TYPE_UINT32 = 'uint32';
-    const TYPE_INT64 = 'int64';
-    const TYPE_UINT64 = 'uint64';
-    const TYPE_FLOAT = 'float';
-    const TYPE_DOUBLE = 'double';
-    const TYPE_STRING = 'string';
+    public const TYPE_BIT = 'bit';
+    public const TYPE_BYTE = 'byte';
+    public const TYPE_INT16 = 'int16';
+    public const TYPE_UINT16 = 'uint16';
+    public const TYPE_INT32 = 'int32';
+    public const TYPE_UINT32 = 'uint32';
+    public const TYPE_INT64 = 'int64';
+    public const TYPE_UINT64 = 'uint64';
+    public const TYPE_FLOAT = 'float';
+    public const TYPE_DOUBLE = 'double';
+    public const TYPE_STRING = 'string';
 
-    const TYPES = [
+    public const TYPES = [
         Address::TYPE_BIT,
         Address::TYPE_BYTE,
         Address::TYPE_INT16,

--- a/src/Composer/AddressSplitter.php
+++ b/src/Composer/AddressSplitter.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Composer;
@@ -13,10 +14,10 @@ abstract class AddressSplitter
      */
     private array $currentUnaddressableRanges = [];
 
-    const UNIT_ID_PREFIX = '||unitId=';
+    public const UNIT_ID_PREFIX = '||unitId=';
 
-    const MAX_REGISTERS_PER_MODBUS_REQUEST = 124;
-    const MAX_COILS_PER_MODBUS_REQUEST = 2048; // response has 1 byte field for count - so 256 * 8 is max
+    public const MAX_REGISTERS_PER_MODBUS_REQUEST = 124;
+    public const MAX_COILS_PER_MODBUS_REQUEST = 2048; // response has 1 byte field for count - so 256 * 8 is max
 
     protected function getMaxAddressesPerModbusRequest(): int
     {
@@ -115,7 +116,7 @@ abstract class AddressSplitter
                 // as those addresses overlap
                 if ($maxAvailableRegister === null || $nextAvailableRegister > $maxAvailableRegister) {
                     $maxAvailableRegister = $nextAvailableRegister;
-                } else if ($nextAvailableRegister < $maxAvailableRegister) {
+                } elseif ($nextAvailableRegister < $maxAvailableRegister) {
                     $nextAvailableRegister = $maxAvailableRegister;
                 }
                 $previousQuantity = $quantity;
@@ -139,7 +140,7 @@ abstract class AddressSplitter
         return $result;
     }
 
-    protected function shouldSplit(Address $currentAddress, int $currentQuantity, Address $previousAddress = null, int $previousQuantity = null): bool
+    protected function shouldSplit(Address $currentAddress, int $currentQuantity, ?Address $previousAddress = null, ?int $previousQuantity = null): bool
     {
         if ($currentQuantity >= $this->getMaxAddressesPerModbusRequest()) {
             return true;

--- a/src/Composer/Range.php
+++ b/src/Composer/Range.php
@@ -29,7 +29,7 @@ class Range
         $count = count($range);
         if ($count == 1) {
             return new Range($range[0], $range[0]);
-        } else if ($count == 2) {
+        } elseif ($count == 2) {
             return new Range($range[0], $range[1]);
         }
         throw new InvalidArgumentException('Range can only be created from array with 1 or 2 elements');

--- a/src/Composer/Read/Coil/ReadCoilAddress.php
+++ b/src/Composer/Read/Coil/ReadCoilAddress.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Composer\Read\Coil;
-
 
 use ModbusTcpClient\Composer\Address;
 use ModbusTcpClient\Packet\ModbusResponse;
@@ -21,7 +21,7 @@ class ReadCoilAddress implements Address
     /** @var callable */
     private $errorCallback;
 
-    public function __construct(int $address, string $name = null, callable $callback = null, callable $errorCallback = null)
+    public function __construct(int $address, ?string $name = null, ?callable $callback = null, ?callable $errorCallback = null)
     {
         $this->address = $address;
         $this->name = $name ?: (string)($address);

--- a/src/Composer/Read/Coil/ReadCoilAddressSplitter.php
+++ b/src/Composer/Read/Coil/ReadCoilAddressSplitter.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Composer\Read\Coil;
-
 
 use ModbusTcpClient\Composer\AddressSplitter;
 

--- a/src/Composer/Read/Coil/ReadCoilRequest.php
+++ b/src/Composer/Read/Coil/ReadCoilRequest.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Composer\Read\Coil;
-
 
 use ModbusTcpClient\Composer\Request;
 use ModbusTcpClient\Exception\ModbusException;

--- a/src/Composer/Read/ReadCoilsBuilder.php
+++ b/src/Composer/Read/ReadCoilsBuilder.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Composer\Read;
@@ -34,7 +35,7 @@ class ReadCoilsBuilder
     /** @var int */
     private int $unitId;
 
-    public function __construct(string $requestClass, string $uri = null, int $unitId = 0)
+    public function __construct(string $requestClass, ?string $uri = null, int $unitId = 0)
     {
         $this->addressSplitter = new ReadCoilAddressSplitter($requestClass);
 
@@ -44,12 +45,12 @@ class ReadCoilsBuilder
         $this->unitId = $unitId;
     }
 
-    public static function newReadCoils(string $uri = null, int $unitId = 0): ReadCoilsBuilder
+    public static function newReadCoils(?string $uri = null, int $unitId = 0): ReadCoilsBuilder
     {
         return new ReadCoilsBuilder(ReadCoilsRequest::class, $uri, $unitId);
     }
 
-    public static function newReadInputDiscretes(string $uri = null, int $unitId = 0): ReadCoilsBuilder
+    public static function newReadInputDiscretes(?string $uri = null, int $unitId = 0): ReadCoilsBuilder
     {
         return new ReadCoilsBuilder(ReadInputDiscretesRequest::class, $uri, $unitId);
     }
@@ -157,11 +158,10 @@ class ReadCoilsBuilder
 
     public function coil(
         int      $address,
-        string   $name = null,
-        callable $callback = null,
-        callable $errorCallback = null
-    ): ReadCoilsBuilder
-    {
+        ?string   $name = null,
+        ?callable $callback = null,
+        ?callable $errorCallback = null
+    ): ReadCoilsBuilder {
         return $this->addAddress(new ReadCoilAddress($address, $name, $callback, $errorCallback));
     }
 
@@ -178,8 +178,3 @@ class ReadCoilsBuilder
         return !empty($this->addresses);
     }
 }
-
-
-
-
-

--- a/src/Composer/Read/ReadRegistersBuilder.php
+++ b/src/Composer/Read/ReadRegistersBuilder.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Composer\Read;
@@ -39,7 +40,7 @@ class ReadRegistersBuilder
     /** @var int */
     private int $unitId;
 
-    public function __construct(string $requestClass, string $uri = null, int $unitId = 0)
+    public function __construct(string $requestClass, ?string $uri = null, int $unitId = 0)
     {
         $this->addressSplitter = new ReadRegisterAddressSplitter($requestClass);
 
@@ -49,12 +50,12 @@ class ReadRegistersBuilder
         $this->unitId = $unitId;
     }
 
-    public static function newReadHoldingRegisters(string $uri = null, int $unitId = 0): ReadRegistersBuilder
+    public static function newReadHoldingRegisters(?string $uri = null, int $unitId = 0): ReadRegistersBuilder
     {
         return new ReadRegistersBuilder(ReadHoldingRegistersRequest::class, $uri, $unitId);
     }
 
-    public static function newReadInputRegisters(string $uri = null, int $unitId = 0): ReadRegistersBuilder
+    public static function newReadInputRegisters(?string $uri = null, int $unitId = 0): ReadRegistersBuilder
     {
         return new ReadRegistersBuilder(ReadInputRegistersRequest::class, $uri, $unitId);
     }
@@ -206,7 +207,7 @@ class ReadRegistersBuilder
         return $this;
     }
 
-    public function bit(int $address, int $nthBit, string $name = null, callable $callback = null, callable $errorCallback = null): ReadRegistersBuilder
+    public function bit(int $address, int $nthBit, ?string $name = null, ?callable $callback = null, ?callable $errorCallback = null): ReadRegistersBuilder
     {
         if ($nthBit < 0 || $nthBit > 15) {
             throw new InvalidArgumentException("Invalid bit number in for register given! nthBit: '{$nthBit}', address: {$address}");
@@ -214,19 +215,18 @@ class ReadRegistersBuilder
         return $this->addAddress(new BitReadRegisterAddress($address, $nthBit, $name, $callback, $errorCallback));
     }
 
-    public function byte(int $address, bool $firstByte = true, string $name = null, callable $callback = null, callable $errorCallback = null): ReadRegistersBuilder
+    public function byte(int $address, bool $firstByte = true, ?string $name = null, ?callable $callback = null, ?callable $errorCallback = null): ReadRegistersBuilder
     {
         return $this->addAddress(new ByteReadRegisterAddress($address, $firstByte, $name, $callback, $errorCallback));
     }
 
     public function int16(
         int      $address,
-        string   $name = null,
-        callable $callback = null,
-        callable $errorCallback = null,
-        int      $endian = null
-    ): ReadRegistersBuilder
-    {
+        ?string   $name = null,
+        ?callable $callback = null,
+        ?callable $errorCallback = null,
+        ?int      $endian = null
+    ): ReadRegistersBuilder {
         $r = new ReadRegisterAddress(
             $address,
             Address::TYPE_INT16,
@@ -240,12 +240,11 @@ class ReadRegistersBuilder
 
     public function uint16(
         int      $address,
-        string   $name = null,
-        callable $callback = null,
-        callable $errorCallback = null,
-        int      $endian = null
-    ): ReadRegistersBuilder
-    {
+        ?string   $name = null,
+        ?callable $callback = null,
+        ?callable $errorCallback = null,
+        ?int      $endian = null
+    ): ReadRegistersBuilder {
         $r = new ReadRegisterAddress(
             $address,
             Address::TYPE_UINT16,
@@ -259,12 +258,11 @@ class ReadRegistersBuilder
 
     public function int32(
         int      $address,
-        string   $name = null,
-        callable $callback = null,
-        callable $errorCallback = null,
-        int      $endian = null
-    ): ReadRegistersBuilder
-    {
+        ?string   $name = null,
+        ?callable $callback = null,
+        ?callable $errorCallback = null,
+        ?int      $endian = null
+    ): ReadRegistersBuilder {
         $r = new ReadRegisterAddress(
             $address,
             Address::TYPE_INT32,
@@ -278,12 +276,11 @@ class ReadRegistersBuilder
 
     public function uint32(
         int      $address,
-        string   $name = null,
-        callable $callback = null,
-        callable $errorCallback = null,
-        int      $endian = null
-    ): ReadRegistersBuilder
-    {
+        ?string   $name = null,
+        ?callable $callback = null,
+        ?callable $errorCallback = null,
+        ?int      $endian = null
+    ): ReadRegistersBuilder {
         $r = new ReadRegisterAddress(
             $address,
             Address::TYPE_UINT32,
@@ -297,12 +294,11 @@ class ReadRegistersBuilder
 
     public function uint64(
         int      $address,
-        string   $name = null,
-        callable $callback = null,
-        callable $errorCallback = null,
-        int      $endian = null
-    ): ReadRegistersBuilder
-    {
+        ?string   $name = null,
+        ?callable $callback = null,
+        ?callable $errorCallback = null,
+        ?int      $endian = null
+    ): ReadRegistersBuilder {
         $r = new ReadRegisterAddress(
             $address,
             Address::TYPE_UINT64,
@@ -316,12 +312,11 @@ class ReadRegistersBuilder
 
     public function int64(
         int      $address,
-        string   $name = null,
-        callable $callback = null,
-        callable $errorCallback = null,
-        int      $endian = null
-    ): ReadRegistersBuilder
-    {
+        ?string   $name = null,
+        ?callable $callback = null,
+        ?callable $errorCallback = null,
+        ?int      $endian = null
+    ): ReadRegistersBuilder {
         $r = new ReadRegisterAddress(
             $address,
             Address::TYPE_INT64,
@@ -335,12 +330,11 @@ class ReadRegistersBuilder
 
     public function float(
         int      $address,
-        string   $name = null,
-        callable $callback = null,
-        callable $errorCallback = null,
-        int      $endian = null
-    ): ReadRegistersBuilder
-    {
+        ?string   $name = null,
+        ?callable $callback = null,
+        ?callable $errorCallback = null,
+        ?int      $endian = null
+    ): ReadRegistersBuilder {
         $r = new ReadRegisterAddress(
             $address,
             Address::TYPE_FLOAT,
@@ -354,12 +348,11 @@ class ReadRegistersBuilder
 
     public function double(
         int      $address,
-        string   $name = null,
-        callable $callback = null,
-        callable $errorCallback = null,
-        int      $endian = null
-    ): ReadRegistersBuilder
-    {
+        ?string   $name = null,
+        ?callable $callback = null,
+        ?callable $errorCallback = null,
+        ?int      $endian = null
+    ): ReadRegistersBuilder {
         $r = new ReadRegisterAddress(
             $address,
             Address::TYPE_DOUBLE,
@@ -374,12 +367,11 @@ class ReadRegistersBuilder
     public function string(
         int      $address,
         int      $byteLength,
-        string   $name = null,
-        callable $callback = null,
-        callable $errorCallback = null,
-        int      $endian = null
-    ): ReadRegistersBuilder
-    {
+        ?string   $name = null,
+        ?callable $callback = null,
+        ?callable $errorCallback = null,
+        ?int      $endian = null
+    ): ReadRegistersBuilder {
         if ($byteLength < 1 || $byteLength > 228) {
             throw new InvalidArgumentException("Out of range string length for given! length: '{$byteLength}', address: {$address}");
         }
@@ -399,8 +391,3 @@ class ReadRegistersBuilder
         return !empty($this->addresses);
     }
 }
-
-
-
-
-

--- a/src/Composer/Read/Register/BitReadRegisterAddress.php
+++ b/src/Composer/Read/Register/BitReadRegisterAddress.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Composer\Read\Register;
@@ -12,7 +13,7 @@ class BitReadRegisterAddress extends ReadRegisterAddress
     /** @var int */
     private int $bit;
 
-    public function __construct(int $address, int $bit, string $name = null, callable $callback = null, callable $errorCallback = null)
+    public function __construct(int $address, int $bit, ?string $name = null, ?callable $callback = null, ?callable $errorCallback = null)
     {
         $type = Address::TYPE_BIT;
         parent::__construct($address, $type, $name ?: "{$type}_{$address}_{$bit}", $callback, $errorCallback);

--- a/src/Composer/Read/Register/ByteReadRegisterAddress.php
+++ b/src/Composer/Read/Register/ByteReadRegisterAddress.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Composer\Read\Register;
-
 
 use ModbusTcpClient\Composer\Address;
 use ModbusTcpClient\Packet\ModbusFunction\ReadHoldingRegistersResponse;
@@ -13,7 +13,7 @@ class ByteReadRegisterAddress extends ReadRegisterAddress
     /** @var bool */
     private bool $firstByte;
 
-    public function __construct(int $address, bool $firstByte, string $name = null, callable $callback = null, callable $errorCallback = null)
+    public function __construct(int $address, bool $firstByte, ?string $name = null, ?callable $callback = null, ?callable $errorCallback = null)
     {
         $type = Address::TYPE_BYTE;
         $fbInt = (int)$firstByte;

--- a/src/Composer/Read/Register/ReadRegisterAddress.php
+++ b/src/Composer/Read/Register/ReadRegisterAddress.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Composer\Read\Register;
-
 
 use ModbusTcpClient\Composer\Address;
 use ModbusTcpClient\Composer\RegisterAddress;
@@ -28,12 +28,11 @@ class ReadRegisterAddress extends RegisterAddress
     public function __construct(
         int      $address,
         string   $type,
-        string   $name = null,
-        callable $callback = null,
-        callable $errorCallback = null,
-        int      $endian = null
-    )
-    {
+        ?string   $name = null,
+        ?callable $callback = null,
+        ?callable $errorCallback = null,
+        ?int      $endian = null
+    ) {
         parent::__construct($address, $type);
 
         $this->endian = $endian === null ? Endian::$defaultEndian : $endian;

--- a/src/Composer/Read/Register/ReadRegisterAddressSplitter.php
+++ b/src/Composer/Read/Register/ReadRegisterAddressSplitter.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Composer\Read\Register;
-
 
 use ModbusTcpClient\Composer\AddressSplitter;
 

--- a/src/Composer/Read/Register/ReadRegisterRequest.php
+++ b/src/Composer/Read/Register/ReadRegisterRequest.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Composer\Read\Register;
-
 
 use ModbusTcpClient\Composer\Request;
 use ModbusTcpClient\Exception\InvalidArgumentException;

--- a/src/Composer/Read/Register/StringReadRegisterAddress.php
+++ b/src/Composer/Read/Register/StringReadRegisterAddress.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Composer\Read\Register;
-
 
 use ModbusTcpClient\Composer\Address;
 use ModbusTcpClient\Packet\ModbusFunction\ReadHoldingRegistersResponse;
@@ -16,12 +16,11 @@ class StringReadRegisterAddress extends ReadRegisterAddress
     public function __construct(
         int      $address,
         int      $byteLength,
-        string   $name = null,
-        callable $callback = null,
-        callable $errorCallback = null,
-        int      $endian = null
-    )
-    {
+        ?string   $name = null,
+        ?callable $callback = null,
+        ?callable $errorCallback = null,
+        ?int      $endian = null
+    ) {
         $type = Address::TYPE_STRING;
         parent::__construct($address, $type, $name ?: "{$type}_{$address}_{$byteLength}", $callback, $errorCallback, $endian);
         $this->byteLength = $byteLength;

--- a/src/Composer/RegisterAddress.php
+++ b/src/Composer/RegisterAddress.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Composer;
-
 
 use ModbusTcpClient\Exception\InvalidArgumentException;
 
@@ -17,7 +17,7 @@ abstract class RegisterAddress implements Address
     /**
      * @return string[]
      */
-    protected abstract function getAllowedTypes(): array;
+    abstract protected function getAllowedTypes(): array;
 
     public function __construct(int $address, string $type)
     {

--- a/src/Composer/Request.php
+++ b/src/Composer/Request.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Composer;
-
 
 use ModbusTcpClient\Packet\ModbusRequest;
 

--- a/src/Composer/Write/Coil/WriteCoilAddress.php
+++ b/src/Composer/Write/Coil/WriteCoilAddress.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Composer\Write\Coil;
-
 
 use ModbusTcpClient\Composer\Address;
 

--- a/src/Composer/Write/Coil/WriteCoilAddressSplitter.php
+++ b/src/Composer/Write/Coil/WriteCoilAddressSplitter.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Composer\Write\Coil;
-
 
 use ModbusTcpClient\Composer\Address;
 use ModbusTcpClient\Composer\AddressSplitter;
@@ -41,7 +41,7 @@ class WriteCoilAddressSplitter extends AddressSplitter
         return static::MAX_COILS_PER_MODBUS_REQUEST;
     }
 
-    protected function shouldSplit(Address $currentAddress, int $currentQuantity, Address $previousAddress = null, int $previousQuantity = null): bool
+    protected function shouldSplit(Address $currentAddress, int $currentQuantity, ?Address $previousAddress = null, ?int $previousQuantity = null): bool
     {
         $isOverAddressLimit = $currentQuantity >= $this->getMaxAddressesPerModbusRequest();
         if ($isOverAddressLimit) {

--- a/src/Composer/Write/Coil/WriteCoilRequest.php
+++ b/src/Composer/Write/Coil/WriteCoilRequest.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Composer\Write\Coil;
-
 
 use ModbusTcpClient\Composer\Request;
 use ModbusTcpClient\Exception\InvalidArgumentException;

--- a/src/Composer/Write/Register/StringWriteRegisterAddress.php
+++ b/src/Composer/Write/Register/StringWriteRegisterAddress.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Composer\Write\Register;
-
 
 use ModbusTcpClient\Composer\Address;
 use ModbusTcpClient\Exception\InvalidArgumentException;
@@ -20,7 +20,7 @@ class StringWriteRegisterAddress extends WriteRegisterAddress
      */
     private ?string $toEncoding;
 
-    public function __construct(int $address, string $value, int $byteLength, string $toEncoding = null)
+    public function __construct(int $address, string $value, int $byteLength, ?string $toEncoding = null)
     {
         parent::__construct($address, Address::TYPE_STRING, $value);
 

--- a/src/Composer/Write/Register/WriteRegisterAddress.php
+++ b/src/Composer/Write/Register/WriteRegisterAddress.php
@@ -2,7 +2,6 @@
 
 namespace ModbusTcpClient\Composer\Write\Register;
 
-
 use ModbusTcpClient\Composer\Address;
 use ModbusTcpClient\Composer\RegisterAddress;
 use ModbusTcpClient\Utils\Types;

--- a/src/Composer/Write/Register/WriteRegisterAddressSplitter.php
+++ b/src/Composer/Write/Register/WriteRegisterAddressSplitter.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Composer\Write\Register;
-
 
 use ModbusTcpClient\Composer\Address;
 use ModbusTcpClient\Composer\AddressSplitter;
@@ -35,7 +35,7 @@ class WriteRegisterAddressSplitter extends AddressSplitter
         return new WriteRegisterRequest($uri, $addressesChunk, new $this->requestClass($startAddress, $binaryStrings, $unitId));
     }
 
-    protected function shouldSplit(Address $currentAddress, int $currentQuantity, Address $previousAddress = null, int $previousQuantity = null): bool
+    protected function shouldSplit(Address $currentAddress, int $currentQuantity, ?Address $previousAddress = null, ?int $previousQuantity = null): bool
     {
         $isOverAddressLimit = $currentQuantity >= $this->getMaxAddressesPerModbusRequest();
         if ($isOverAddressLimit) {

--- a/src/Composer/Write/Register/WriteRegisterRequest.php
+++ b/src/Composer/Write/Register/WriteRegisterRequest.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Composer\Write\Register;
-
 
 use ModbusTcpClient\Composer\Request;
 use ModbusTcpClient\Exception\InvalidArgumentException;

--- a/src/Composer/Write/WriteCoilsBuilder.php
+++ b/src/Composer/Write/WriteCoilsBuilder.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Composer\Write;
-
 
 use ModbusTcpClient\Composer\AddressSplitter;
 use ModbusTcpClient\Composer\Request;
@@ -25,7 +25,7 @@ class WriteCoilsBuilder
     /** @var int */
     private int $unitId;
 
-    public function __construct(string $requestClass, string $uri = null, int $unitId = 0)
+    public function __construct(string $requestClass, ?string $uri = null, int $unitId = 0)
     {
         $this->addressSplitter = new WriteCoilAddressSplitter($requestClass);
 
@@ -35,7 +35,7 @@ class WriteCoilsBuilder
         $this->unitId = $unitId;
     }
 
-    public static function newWriteMultipleCoils(string $uri = null, int $unitId = 0): WriteCoilsBuilder
+    public static function newWriteMultipleCoils(?string $uri = null, int $unitId = 0): WriteCoilsBuilder
     {
         return new WriteCoilsBuilder(WriteMultipleCoilsRequest::class, $uri, $unitId);
     }

--- a/src/Composer/Write/WriteRegistersBuilder.php
+++ b/src/Composer/Write/WriteRegistersBuilder.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Composer\Write;
-
 
 use ModbusTcpClient\Composer\Address;
 use ModbusTcpClient\Composer\AddressSplitter;
@@ -27,7 +27,7 @@ class WriteRegistersBuilder
     /** @var int */
     private int $unitId;
 
-    public function __construct(string $requestClass, string $uri = null, int $unitId = 0)
+    public function __construct(string $requestClass, ?string $uri = null, int $unitId = 0)
     {
         $this->addressSplitter = new WriteRegisterAddressSplitter($requestClass);
 
@@ -37,7 +37,7 @@ class WriteRegistersBuilder
         $this->unitId = $unitId;
     }
 
-    public static function newWriteMultipleRegisters(string $uri = null, int $unitId = 0): WriteRegistersBuilder
+    public static function newWriteMultipleRegisters(?string $uri = null, int $unitId = 0): WriteRegistersBuilder
     {
         return new WriteRegistersBuilder(WriteMultipleRegistersRequest::class, $uri, $unitId);
     }
@@ -187,7 +187,7 @@ class WriteRegistersBuilder
         return $this->addAddress(new WriteRegisterAddress($address, Address::TYPE_DOUBLE, $value));
     }
 
-    public function string(int $address, string $string, int $byteLength = null): WriteRegistersBuilder
+    public function string(int $address, string $string, ?int $byteLength = null): WriteRegistersBuilder
     {
         return $this->addAddress(new StringWriteRegisterAddress($address, $string, $byteLength));
     }

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,10 +1,9 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Exception;
 
-
 class InvalidArgumentException extends ModbusException
 {
-
 }

--- a/src/Exception/ModbusException.php
+++ b/src/Exception/ModbusException.php
@@ -1,10 +1,9 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Exception;
 
-
 class ModbusException extends \RuntimeException
 {
-
 }

--- a/src/Exception/OverflowException.php
+++ b/src/Exception/OverflowException.php
@@ -1,10 +1,9 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Exception;
 
-
 class OverflowException extends ParseException
 {
-
 }

--- a/src/Exception/ParseException.php
+++ b/src/Exception/ParseException.php
@@ -1,10 +1,9 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Exception;
 
-
 class ParseException extends ModbusException
 {
-
 }

--- a/src/Network/BinaryStreamConnection.php
+++ b/src/Network/BinaryStreamConnection.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Network;

--- a/src/Network/BinaryStreamConnectionBuilder.php
+++ b/src/Network/BinaryStreamConnectionBuilder.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Network;
-
 
 use ModbusTcpClient\Exception\InvalidArgumentException;
 use ModbusTcpClient\Utils\Packet;
@@ -167,7 +167,7 @@ class BinaryStreamConnectionBuilder extends BinaryStreamConnectionProperties
      * @param array<string,mixed>|null $options
      * @return $this
      */
-    public function setFromOptions(array $options = null): static
+    public function setFromOptions(?array $options = null): static
     {
         if ($options !== null) {
             foreach ($options as $option => $value) {

--- a/src/Network/BinaryStreamConnectionProperties.php
+++ b/src/Network/BinaryStreamConnectionProperties.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Network;

--- a/src/Network/IOException.php
+++ b/src/Network/IOException.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Network;
@@ -10,5 +11,4 @@ use ModbusTcpClient\Exception\ModbusException;
  */
 class IOException extends ModbusException
 {
-
 }

--- a/src/Network/InternetDomainStreamCreator.php
+++ b/src/Network/InternetDomainStreamCreator.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Network;

--- a/src/Network/NonBlockingClient.php
+++ b/src/Network/NonBlockingClient.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Network;
-
 
 use ModbusTcpClient\Composer\Request;
 use ModbusTcpClient\Exception\ModbusException;
@@ -17,8 +17,8 @@ class NonBlockingClient
 {
     use StreamHandler;
 
-    const OPT_FLAT_REQUEST_RESPONSE = 'flatRequestResponse';
-    const OPT_THROW_ON_ERROR = 'throwOnError';
+    public const OPT_FLAT_REQUEST_RESPONSE = 'flatRequestResponse';
+    public const OPT_THROW_ON_ERROR = 'throwOnError';
 
     /**
      * @var array<string, mixed>
@@ -31,7 +31,7 @@ class NonBlockingClient
     /**
      * @param array<string, mixed>|null $options
      */
-    public function __construct(array $options = null)
+    public function __construct(?array $options = null)
     {
         $this->options = $this->getMergeOptions($options);
     }
@@ -44,7 +44,7 @@ class NonBlockingClient
      * @param array<string, mixed>|null $options
      * @return ModbusResponse[]
      */
-    public function sendPackets(array $packets, string $uri = null, array $options = null): array
+    public function sendPackets(array $packets, ?string $uri = null, ?array $options = null): array
     {
         $readStreams = [];
         $connections = [];
@@ -102,7 +102,7 @@ class NonBlockingClient
      * @param array<string, mixed>|null $options
      * @return ModbusPacket
      */
-    public function sendPacket(ModbusPacket $packet, string $uri = null, array $options = null): ModbusPacket
+    public function sendPacket(ModbusPacket $packet, ?string $uri = null, ?array $options = null): ModbusPacket
     {
         $responses = $this->sendPackets([$packet], $uri, $options);
         return reset($responses);
@@ -115,7 +115,7 @@ class NonBlockingClient
      * @param array<string, mixed>|null $options options for tcp stream. See 'BinaryStreamConnection' properties.
      * @return ResultContainer
      */
-    public function sendRequests(array $requests, array $options = null): ResultContainer
+    public function sendRequests(array $requests, ?array $options = null): ResultContainer
     {
         $readStreams = [];
         $connections = [];
@@ -193,7 +193,7 @@ class NonBlockingClient
      * @param array<string, mixed>|null $options
      * @return ResultContainer
      */
-    public function sendRequest(Request $request, array $options = null): ResultContainer
+    public function sendRequest(Request $request, ?array $options = null): ResultContainer
     {
         return $this->sendRequests([$request], $options);
     }
@@ -202,7 +202,7 @@ class NonBlockingClient
      * @param array<string, mixed>|null $options
      * @return array<string, mixed>
      */
-    private function getMergeOptions(array $options = null): array
+    private function getMergeOptions(?array $options = null): array
     {
         if (!empty($options)) {
             return array_merge($this->options, $options);

--- a/src/Network/ResultContainer.php
+++ b/src/Network/ResultContainer.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Network;
-
 
 use ArrayIterator;
 use ModbusTcpClient\Exception\ModbusException;

--- a/src/Network/SerialStreamCreator.php
+++ b/src/Network/SerialStreamCreator.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Network;
-
 
 class SerialStreamCreator implements StreamCreator
 {
@@ -11,7 +11,7 @@ class SerialStreamCreator implements StreamCreator
      *
      * Dear reader - if you know that some option are not needed here then add a comment/issue in github
      */
-    const DEFAULT_STTY_MODES = [
+    public const DEFAULT_STTY_MODES = [
         'cs8', // set character size 8 bits
         '9600', // set baud rate 9600
         '-cstopb', // 1 stop bit

--- a/src/Network/StreamCreator.php
+++ b/src/Network/StreamCreator.php
@@ -1,14 +1,14 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Network;
 
-
 interface StreamCreator
 {
-    const TYPE_TCP = 'tcp';
-    const TYPE_UDP = 'udp';
-    const TYPE_SERIAL = 'serial';
+    public const TYPE_TCP = 'tcp';
+    public const TYPE_UDP = 'udp';
+    public const TYPE_SERIAL = 'serial';
 
     /**
      * @param BinaryStreamConnection $conn

--- a/src/Network/StreamHandler.php
+++ b/src/Network/StreamHandler.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Network;
@@ -17,7 +18,7 @@ trait StreamHandler
      * @param LoggerInterface|null $logger
      * @return string[]
      */
-    protected function receiveFrom(array $readStreams, float $timeout = null, LoggerInterface $logger = null): array
+    protected function receiveFrom(array $readStreams, ?float $timeout = null, ?LoggerInterface $logger = null): array
     {
         if ($timeout === null) {
             $timeout = 0.3;

--- a/src/Packet/AbstractWord.php
+++ b/src/Packet/AbstractWord.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Packet;
@@ -39,7 +40,7 @@ abstract class AbstractWord
      *
      * @return int
      */
-    protected abstract function getByteLength(): int;
+    abstract protected function getByteLength(): int;
 
     /**
      * @return string

--- a/src/Packet/ByteCountResponse.php
+++ b/src/Packet/ByteCountResponse.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Packet;
-
 
 use ModbusTcpClient\Exception\ParseException;
 use ModbusTcpClient\Utils\Types;
@@ -15,7 +15,7 @@ abstract class ByteCountResponse extends ProtocolDataUnit implements ModbusRespo
     /** @var int */
     private int $startAddress = 0;
 
-    public function __construct(string $rawData, int $unitId = 0, int $transactionId = null)
+    public function __construct(string $rawData, int $unitId = 0, ?int $transactionId = null)
     {
         $this->byteCount = Types::parseByte($rawData[0]);
 

--- a/src/Packet/DoubleWord.php
+++ b/src/Packet/DoubleWord.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Packet;
@@ -23,7 +24,7 @@ class DoubleWord extends AbstractWord
      *
      * @return int|float
      */
-    public function getUInt32(int $endianness = null): int|float
+    public function getUInt32(?int $endianness = null): int|float
     {
         return Types::parseUInt32($this->getData(), $endianness);
     }
@@ -32,7 +33,7 @@ class DoubleWord extends AbstractWord
      * @param int|null $endianness byte and word order for modbus binary data
      * @return int
      */
-    public function getInt32(int $endianness = null): int
+    public function getInt32(?int $endianness = null): int
     {
         return Types::parseInt32($this->getData(), $endianness);
     }
@@ -41,7 +42,7 @@ class DoubleWord extends AbstractWord
      * @param int|null $endianness byte and word order for modbus binary data
      * @return float
      */
-    public function getFloat(int $endianness = null): float
+    public function getFloat(?int $endianness = null): float
     {
         return Types::parseFloat($this->getData(), $endianness);
     }

--- a/src/Packet/ErrorResponse.php
+++ b/src/Packet/ErrorResponse.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Packet;
-
 
 use ModbusTcpClient\Utils\Types;
 
@@ -23,7 +23,7 @@ class ErrorResponse implements ModbusResponse
     /**
      * @var int Modbus exceptions are transferred in function code byte and have their high bit set (128)
      */
-    const EXCEPTION_BITMASK = 128;
+    public const EXCEPTION_BITMASK = 128;
 
     /**
      * @var ModbusApplicationHeader

--- a/src/Packet/ModbusApplicationHeader.php
+++ b/src/Packet/ModbusApplicationHeader.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Packet;
-
 
 use ModbusTcpClient\Exception\InvalidArgumentException;
 use ModbusTcpClient\Exception\ModbusException;
@@ -25,7 +25,7 @@ class ModbusApplicationHeader
     /**
      * @var int 2 bytes set by the Client, always = 00 00
      */
-    const PROTOCOL_ID = 0;
+    public const PROTOCOL_ID = 0;
 
     /**
      * @var int 2 bytes set by the Client to uniquely identify each request. These bytes are echoed by the Server since its responses may not be received in the same order as the requests.
@@ -43,7 +43,7 @@ class ModbusApplicationHeader
      */
     private int $unitId = 0;
 
-    public function __construct(int $length, int $unitId = 0, int $transactionId = null)
+    public function __construct(int $length, int $unitId = 0, ?int $transactionId = null)
     {
         $this->validate($length, $unitId, $transactionId);
 

--- a/src/Packet/ModbusFunction/GetCommEventCounterRequest.php
+++ b/src/Packet/ModbusFunction/GetCommEventCounterRequest.php
@@ -21,7 +21,7 @@ use ModbusTcpClient\Utils\Types;
  */
 class GetCommEventCounterRequest extends ProtocolDataUnit implements ModbusRequest
 {
-    public function __construct(int $unitId = 0, int $transactionId = null)
+    public function __construct(int $unitId = 0, ?int $transactionId = null)
     {
         parent::__construct($unitId, $transactionId);
     }

--- a/src/Packet/ModbusFunction/GetCommEventCounterResponse.php
+++ b/src/Packet/ModbusFunction/GetCommEventCounterResponse.php
@@ -33,7 +33,7 @@ class GetCommEventCounterResponse extends ProtocolDataUnit implements ModbusResp
      */
     private int $eventCount;
 
-    public function __construct(string $rawData, int $unitId = 0, int $transactionId = null)
+    public function __construct(string $rawData, int $unitId = 0, ?int $transactionId = null)
     {
         parent::__construct($unitId, $transactionId);
         $this->status = Types::parseUInt16(substr($rawData, 0, 2), Endian::BIG_ENDIAN);

--- a/src/Packet/ModbusFunction/MaskWriteRegisterRequest.php
+++ b/src/Packet/ModbusFunction/MaskWriteRegisterRequest.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Packet\ModbusFunction;
-
 
 use ModbusTcpClient\Exception\InvalidArgumentException;
 use ModbusTcpClient\Packet\ErrorResponse;
@@ -39,7 +39,7 @@ class MaskWriteRegisterRequest extends ProtocolDataUnitRequest implements Modbus
      */
     private int $orMask;
 
-    public function __construct(int $startAddress, int $andMask, int $orMask, int $unitId = 0, int $transactionId = null)
+    public function __construct(int $startAddress, int $andMask, int $orMask, int $unitId = 0, ?int $transactionId = null)
     {
         parent::__construct($startAddress, $unitId, $transactionId);
         $this->andMask = $andMask;

--- a/src/Packet/ModbusFunction/MaskWriteRegisterResponse.php
+++ b/src/Packet/ModbusFunction/MaskWriteRegisterResponse.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Packet\ModbusFunction;
@@ -35,7 +36,7 @@ class MaskWriteRegisterResponse extends StartAddressResponse
      */
     private int $orMask;
 
-    public function __construct(string $rawData, int $unitId = 0, int $transactionId = null)
+    public function __construct(string $rawData, int $unitId = 0, ?int $transactionId = null)
     {
         parent::__construct($rawData, $unitId, $transactionId);
         $this->andMask = Types::parseUInt16(substr($rawData, 2, 2), Endian::BIG_ENDIAN);

--- a/src/Packet/ModbusFunction/ReadCoilsRequest.php
+++ b/src/Packet/ModbusFunction/ReadCoilsRequest.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Packet\ModbusFunction;
-
 
 use ModbusTcpClient\Exception\InvalidArgumentException;
 use ModbusTcpClient\Packet\ErrorResponse;
@@ -32,7 +32,7 @@ class ReadCoilsRequest extends ProtocolDataUnitRequest implements ModbusRequest
      */
     private int $quantity;
 
-    public function __construct(int $startAddress, int $quantity, int $unitId = 0, int $transactionId = null)
+    public function __construct(int $startAddress, int $quantity, int $unitId = 0, ?int $transactionId = null)
     {
         parent::__construct($startAddress, $unitId, $transactionId);
         $this->quantity = $quantity;

--- a/src/Packet/ModbusFunction/ReadCoilsResponse.php
+++ b/src/Packet/ModbusFunction/ReadCoilsResponse.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Packet\ModbusFunction;
@@ -36,7 +37,7 @@ class ReadCoilsResponse extends ByteCountResponse implements \ArrayAccess, \Iter
      */
     private int $coilsBytesLength;
 
-    public function __construct(string $rawData, int $unitId = 0, int $transactionId = null)
+    public function __construct(string $rawData, int $unitId = 0, ?int $transactionId = null)
     {
         $data = substr($rawData, 1);
         $this->coilsBytesLength = strlen($data);

--- a/src/Packet/ModbusFunction/ReadHoldingRegistersRequest.php
+++ b/src/Packet/ModbusFunction/ReadHoldingRegistersRequest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Packet\ModbusFunction;
@@ -31,7 +32,7 @@ class ReadHoldingRegistersRequest extends ProtocolDataUnitRequest implements Mod
      */
     private int $quantity;
 
-    public function __construct(int $startAddress, int $quantity, int $unitId = 0, int $transactionId = null)
+    public function __construct(int $startAddress, int $quantity, int $unitId = 0, ?int $transactionId = null)
     {
         parent::__construct($startAddress, $unitId, $transactionId);
 

--- a/src/Packet/ModbusFunction/ReadHoldingRegistersResponse.php
+++ b/src/Packet/ModbusFunction/ReadHoldingRegistersResponse.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Packet\ModbusFunction;
-
 
 use ModbusTcpClient\Exception\InvalidArgumentException;
 use ModbusTcpClient\Exception\ModbusException;
@@ -39,7 +39,7 @@ class ReadHoldingRegistersResponse extends ByteCountResponse implements \ArrayAc
     /** @var int[] */
     private array $dataBytes;
 
-    public function __construct(string $rawData, int $unitId = 0, int $transactionId = null)
+    public function __construct(string $rawData, int $unitId = 0, ?int $transactionId = null)
     {
         parent::__construct($rawData, $unitId, $transactionId);
         $this->data = substr($rawData, 1); //first byte is byteCount. remove it
@@ -201,7 +201,7 @@ class ReadHoldingRegistersResponse extends ByteCountResponse implements \ArrayAc
      * @param int|null $endianness byte and word order for modbus binary data
      * @return string
      */
-    public function getAsciiStringAt(int $startFromWord, int $length, int $endianness = null): string
+    public function getAsciiStringAt(int $startFromWord, int $length, ?int $endianness = null): string
     {
         $address = ($startFromWord - $this->getStartAddress()) * 2;
 

--- a/src/Packet/ModbusFunction/ReadInputDiscretesRequest.php
+++ b/src/Packet/ModbusFunction/ReadInputDiscretesRequest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Packet\ModbusFunction;

--- a/src/Packet/ModbusFunction/ReadInputDiscretesResponse.php
+++ b/src/Packet/ModbusFunction/ReadInputDiscretesResponse.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Packet\ModbusFunction;

--- a/src/Packet/ModbusFunction/ReadInputRegistersRequest.php
+++ b/src/Packet/ModbusFunction/ReadInputRegistersRequest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Packet\ModbusFunction;

--- a/src/Packet/ModbusFunction/ReadInputRegistersResponse.php
+++ b/src/Packet/ModbusFunction/ReadInputRegistersResponse.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Packet\ModbusFunction;

--- a/src/Packet/ModbusFunction/ReadWriteMultipleRegistersRequest.php
+++ b/src/Packet/ModbusFunction/ReadWriteMultipleRegistersRequest.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Packet\ModbusFunction;
-
 
 use ModbusTcpClient\Exception\InvalidArgumentException;
 use ModbusTcpClient\Packet\ErrorResponse;
@@ -59,9 +59,8 @@ class ReadWriteMultipleRegistersRequest extends ProtocolDataUnitRequest implemen
         int   $writeStartAddress,
         array $writeRegisters,
         int   $unitId = 0,
-        int   $transactionId = null
-    )
-    {
+        ?int   $transactionId = null
+    ) {
         $this->readQuantity = $readQuantity;
         $this->writeStartAddress = $writeStartAddress;
         $this->writeRegisters = $writeRegisters;

--- a/src/Packet/ModbusFunction/ReadWriteMultipleRegistersResponse.php
+++ b/src/Packet/ModbusFunction/ReadWriteMultipleRegistersResponse.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Packet\ModbusFunction;
-
 
 use ModbusTcpClient\Exception\InvalidArgumentException;
 use ModbusTcpClient\Exception\ModbusException;
@@ -39,7 +39,7 @@ class ReadWriteMultipleRegistersResponse extends ByteCountResponse implements \A
     /** @var int[] */
     private array $dataBytes;
 
-    public function __construct(string $rawData, int $unitId = 0, int $transactionId = null)
+    public function __construct(string $rawData, int $unitId = 0, ?int $transactionId = null)
     {
         parent::__construct($rawData, $unitId, $transactionId);
         $this->data = substr($rawData, 1); //first byte is byteCount. remove it
@@ -200,7 +200,7 @@ class ReadWriteMultipleRegistersResponse extends ByteCountResponse implements \A
      * @param int|null $endianness byte and word order for modbus binary data
      * @return string
      */
-    public function getAsciiStringAt(int $startFromWord, int $length, int $endianness = null): string
+    public function getAsciiStringAt(int $startFromWord, int $length, ?int $endianness = null): string
     {
         $address = ($startFromWord - $this->getStartAddress()) * 2;
 

--- a/src/Packet/ModbusFunction/ReportServerIDRequest.php
+++ b/src/Packet/ModbusFunction/ReportServerIDRequest.php
@@ -21,7 +21,7 @@ use ModbusTcpClient\Utils\Types;
  */
 class ReportServerIDRequest extends ProtocolDataUnit implements ModbusRequest
 {
-    public function __construct(int $unitId = 0, int $transactionId = null)
+    public function __construct(int $unitId = 0, ?int $transactionId = null)
     {
         parent::__construct($unitId, $transactionId);
     }

--- a/src/Packet/ModbusFunction/ReportServerIDResponse.php
+++ b/src/Packet/ModbusFunction/ReportServerIDResponse.php
@@ -40,7 +40,7 @@ class ReportServerIDResponse extends ProtocolDataUnit implements ModbusResponse
      */
     private ?string $additionalData = null;
 
-    public function __construct(string $rawData, int $unitId = 0, int $transactionId = null)
+    public function __construct(string $rawData, int $unitId = 0, ?int $transactionId = null)
     {
         $serverIDLength = Types::parseByte($rawData[0]);
         if (strlen($rawData) < ($serverIDLength + 2)) {

--- a/src/Packet/ModbusFunction/WriteMultipleCoilsRequest.php
+++ b/src/Packet/ModbusFunction/WriteMultipleCoilsRequest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Packet\ModbusFunction;
@@ -42,7 +43,7 @@ class WriteMultipleCoilsRequest extends ProtocolDataUnitRequest implements Modbu
      * @param int $unitId
      * @param int|null $transactionId
      */
-    public function __construct(int $startAddress, array $coils, int $unitId = 0, int $transactionId = null)
+    public function __construct(int $startAddress, array $coils, int $unitId = 0, ?int $transactionId = null)
     {
         $this->coils = $coils;
         $this->coilCount = count($this->coils);

--- a/src/Packet/ModbusFunction/WriteMultipleCoilsResponse.php
+++ b/src/Packet/ModbusFunction/WriteMultipleCoilsResponse.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Packet\ModbusFunction;
@@ -28,7 +29,7 @@ class WriteMultipleCoilsResponse extends StartAddressResponse
      */
     private int $coilCount;
 
-    public function __construct(string $rawData, int $unitId = 0, int $transactionId = null)
+    public function __construct(string $rawData, int $unitId = 0, ?int $transactionId = null)
     {
         parent::__construct($rawData, $unitId, $transactionId);
         $this->coilCount = Types::parseUInt16(substr($rawData, 2, 2), Endian::BIG_ENDIAN);

--- a/src/Packet/ModbusFunction/WriteMultipleRegistersRequest.php
+++ b/src/Packet/ModbusFunction/WriteMultipleRegistersRequest.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Packet\ModbusFunction;
-
 
 use ModbusTcpClient\Exception\InvalidArgumentException;
 use ModbusTcpClient\Packet\ErrorResponse;
@@ -44,7 +44,7 @@ class WriteMultipleRegistersRequest extends ProtocolDataUnitRequest implements M
      * @param int $unitId
      * @param int|null $transactionId
      */
-    public function __construct(int $startAddress, array $registers, int $unitId = 0, int $transactionId = null)
+    public function __construct(int $startAddress, array $registers, int $unitId = 0, ?int $transactionId = null)
     {
         $this->registers = $registers;
         $this->registersBytesSize = Registers::getRegisterArrayByteSize($this->registers);

--- a/src/Packet/ModbusFunction/WriteMultipleRegistersResponse.php
+++ b/src/Packet/ModbusFunction/WriteMultipleRegistersResponse.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Packet\ModbusFunction;
@@ -28,7 +29,7 @@ class WriteMultipleRegistersResponse extends StartAddressResponse
      */
     private int $registersCount;
 
-    public function __construct(string $rawData, int $unitId = 0, int $transactionId = null)
+    public function __construct(string $rawData, int $unitId = 0, ?int $transactionId = null)
     {
         parent::__construct($rawData, $unitId, $transactionId);
         $this->registersCount = Types::parseUInt16(substr($rawData, 2, 2), Endian::BIG_ENDIAN);

--- a/src/Packet/ModbusFunction/WriteSingleCoilRequest.php
+++ b/src/Packet/ModbusFunction/WriteSingleCoilRequest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Packet\ModbusFunction;
@@ -8,7 +9,6 @@ use ModbusTcpClient\Packet\ModbusPacket;
 use ModbusTcpClient\Packet\ModbusRequest;
 use ModbusTcpClient\Packet\ProtocolDataUnitRequest;
 use ModbusTcpClient\Utils\Types;
-
 
 /**
  * Request for Write Single Coil (FC=05)
@@ -25,15 +25,15 @@ use ModbusTcpClient\Utils\Types;
  */
 class WriteSingleCoilRequest extends ProtocolDataUnitRequest implements ModbusRequest
 {
-    const ON = 0xFF;
-    const OFF = 0x0;
+    public const ON = 0xFF;
+    public const OFF = 0x0;
 
     /**
      * @var bool value to be sent to modbus
      */
     private bool $coil;
 
-    public function __construct(int $startAddress, bool $coil, int $unitId = 0, int $transactionId = null)
+    public function __construct(int $startAddress, bool $coil, int $unitId = 0, ?int $transactionId = null)
     {
         parent::__construct($startAddress, $unitId, $transactionId);
         $this->coil = $coil;

--- a/src/Packet/ModbusFunction/WriteSingleCoilResponse.php
+++ b/src/Packet/ModbusFunction/WriteSingleCoilResponse.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Packet\ModbusFunction;
@@ -26,15 +27,15 @@ use ModbusTcpClient\Utils\Types;
  */
 class WriteSingleCoilResponse extends StartAddressResponse
 {
-    const ON = 0xFF;
-    const OFF = 0x0;
+    public const ON = 0xFF;
+    public const OFF = 0x0;
 
     /**
      * @var bool
      */
     private bool $coil;
 
-    public function __construct(string $rawData, int $unitId = 0, int $transactionId = null)
+    public function __construct(string $rawData, int $unitId = 0, ?int $transactionId = null)
     {
         parent::__construct($rawData, $unitId, $transactionId);
         $this->coil = ord($rawData[2]) === self::ON;

--- a/src/Packet/ModbusFunction/WriteSingleRegisterRequest.php
+++ b/src/Packet/ModbusFunction/WriteSingleRegisterRequest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Packet\ModbusFunction;
@@ -11,7 +12,6 @@ use ModbusTcpClient\Packet\ProtocolDataUnitRequest;
 use ModbusTcpClient\Packet\Word;
 use ModbusTcpClient\Utils\Endian;
 use ModbusTcpClient\Utils\Types;
-
 
 /**
  * Request for Write Single Register (FC=06)
@@ -28,13 +28,12 @@ use ModbusTcpClient\Utils\Types;
  */
 class WriteSingleRegisterRequest extends ProtocolDataUnitRequest implements ModbusRequest
 {
-
     /**
      * @var int value to be sent to modbus
      */
     private int $value;
 
-    public function __construct(int $startAddress, int $value, int $unitId = 0, int $transactionId = null)
+    public function __construct(int $startAddress, int $value, int $unitId = 0, ?int $transactionId = null)
     {
         parent::__construct($startAddress, $unitId, $transactionId);
         $this->value = $value;

--- a/src/Packet/ModbusFunction/WriteSingleRegisterResponse.php
+++ b/src/Packet/ModbusFunction/WriteSingleRegisterResponse.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Packet\ModbusFunction;
@@ -27,7 +28,7 @@ class WriteSingleRegisterResponse extends StartAddressResponse
      */
     private Word $word;
 
-    public function __construct(string $rawData, int $unitId = 0, int $transactionId = null)
+    public function __construct(string $rawData, int $unitId = 0, ?int $transactionId = null)
     {
         parent::__construct($rawData, $unitId, $transactionId);
         $this->word = new Word(substr($rawData, 2, 2));

--- a/src/Packet/ModbusPacket.php
+++ b/src/Packet/ModbusPacket.php
@@ -1,23 +1,23 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Packet;
 
-
 interface ModbusPacket
 {
-    const READ_COILS = 1; // 0x01
-    const READ_INPUT_DISCRETES = 2; // 0x02
-    const READ_HOLDING_REGISTERS = 3; // 0x03
-    const READ_INPUT_REGISTERS = 4; // 0x04
-    const WRITE_SINGLE_COIL = 5; // 0x05
-    const WRITE_SINGLE_REGISTER = 6; // 0x06
-    const GET_COMM_EVENT_COUNTER = 11; // 0x0B
-    const WRITE_MULTIPLE_COILS = 15; // 0x0F
-    const WRITE_MULTIPLE_REGISTERS = 16; // 0x10
-    const REPORT_SERVER_ID = 17; // 0x11
-    const MASK_WRITE_REGISTER = 22; // 0x16
-    const READ_WRITE_MULTIPLE_REGISTERS = 23; // 0x17
+    public const READ_COILS = 1; // 0x01
+    public const READ_INPUT_DISCRETES = 2; // 0x02
+    public const READ_HOLDING_REGISTERS = 3; // 0x03
+    public const READ_INPUT_REGISTERS = 4; // 0x04
+    public const WRITE_SINGLE_COIL = 5; // 0x05
+    public const WRITE_SINGLE_REGISTER = 6; // 0x06
+    public const GET_COMM_EVENT_COUNTER = 11; // 0x0B
+    public const WRITE_MULTIPLE_COILS = 15; // 0x0F
+    public const WRITE_MULTIPLE_REGISTERS = 16; // 0x10
+    public const REPORT_SERVER_ID = 17; // 0x11
+    public const MASK_WRITE_REGISTER = 22; // 0x16
+    public const READ_WRITE_MULTIPLE_REGISTERS = 23; // 0x17
 
 
     /**

--- a/src/Packet/ModbusRequest.php
+++ b/src/Packet/ModbusRequest.php
@@ -1,11 +1,10 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Packet;
 
-
 // Marker interface to help distinguish requests from responses
 interface ModbusRequest extends ModbusPacket
 {
-
 }

--- a/src/Packet/ModbusResponse.php
+++ b/src/Packet/ModbusResponse.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Packet;
-
 
 interface ModbusResponse extends ModbusPacket
 {

--- a/src/Packet/ProtocolDataUnit.php
+++ b/src/Packet/ProtocolDataUnit.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Packet;
-
 
 /*
  * Here is an example of a Modbus RTU request for the content of analog output holding registers # 40108 to 40110.
@@ -24,7 +24,7 @@ abstract class ProtocolDataUnit implements ModbusPacket
      */
     private ModbusApplicationHeader $header;
 
-    public function __construct(int $unitId = 0, int $transactionId = null)
+    public function __construct(int $unitId = 0, ?int $transactionId = null)
     {
         $this->header = new ModbusApplicationHeader($this->getLengthInternal(), $unitId, $transactionId);
     }
@@ -55,7 +55,8 @@ abstract class ProtocolDataUnit implements ModbusPacket
     protected static function parsePacket(string|null $binaryString, int $minLength, int $functionCode, callable $createFunctor): mixed
     {
         if ($binaryString === null || strlen($binaryString) < $minLength) {
-            return new ErrorResponse(new ModbusApplicationHeader(2, 0, 0),
+            return new ErrorResponse(
+                new ModbusApplicationHeader(2, 0, 0),
                 $functionCode,
                 4 // Server failure
             );

--- a/src/Packet/ProtocolDataUnitRequest.php
+++ b/src/Packet/ProtocolDataUnitRequest.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Packet;
-
 
 /*
  * Here is an example of a Modbus RTU request for the content of analog output holding registers # 40108 to 40110.
@@ -21,7 +21,7 @@ abstract class ProtocolDataUnitRequest extends ProtocolDataUnit
 {
     private int $startAddress;
 
-    public function __construct(int $startAddress, int $unitId = 0, int $transactionId = null)
+    public function __construct(int $startAddress, int $unitId = 0, ?int $transactionId = null)
     {
         parent::__construct($unitId, $transactionId);
 
@@ -63,7 +63,8 @@ abstract class ProtocolDataUnitRequest extends ProtocolDataUnit
     protected static function parseStartAddressPacket(string|null $binaryString, int $minLength, int $functionCode, callable $createFunctor): mixed
     {
         if ($binaryString === null || strlen($binaryString) < $minLength) {
-            return new ErrorResponse(new ModbusApplicationHeader(2, 0, 0),
+            return new ErrorResponse(
+                new ModbusApplicationHeader(2, 0, 0),
                 $functionCode,
                 4 // Server failure
             );

--- a/src/Packet/QuadWord.php
+++ b/src/Packet/QuadWord.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Packet;
@@ -20,7 +21,7 @@ class QuadWord extends AbstractWord
      * @param int|null $endianness byte and word order for modbus binary data
      * @return int
      */
-    public function getUInt64(int $endianness = null): int
+    public function getUInt64(?int $endianness = null): int
     {
         return Types::parseUInt64($this->getData(), $endianness);
     }
@@ -29,7 +30,7 @@ class QuadWord extends AbstractWord
      * @param int|null $endianness byte and word order for modbus binary data
      * @return int
      */
-    public function getInt64(int $endianness = null): int
+    public function getInt64(?int $endianness = null): int
     {
         return Types::parseInt64($this->getData(), $endianness);
     }
@@ -38,7 +39,7 @@ class QuadWord extends AbstractWord
      * @param int|null $endianness byte and word order for modbus binary data
      * @return float
      */
-    public function getDouble(int $endianness = null): float
+    public function getDouble(?int $endianness = null): float
     {
         return Types::parseDouble($this->getData(), $endianness);
     }

--- a/src/Packet/RequestFactory.php
+++ b/src/Packet/RequestFactory.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Packet;
-
 
 use ModbusTcpClient\Exception\ModbusException;
 use ModbusTcpClient\Packet\ModbusFunction\GetCommEventCounterRequest;

--- a/src/Packet/ResponseFactory.php
+++ b/src/Packet/ResponseFactory.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Packet;
-
 
 use ModbusTcpClient\Exception\ModbusException;
 use ModbusTcpClient\Exception\ParseException;

--- a/src/Packet/RtuConverter.php
+++ b/src/Packet/RtuConverter.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Packet;
-
 
 use ModbusTcpClient\Exception\ModbusException;
 use ModbusTcpClient\Exception\ParseException;
@@ -57,7 +57,8 @@ final class RtuConverter
             $calculatedCrc = self::crc16($data);
             if ($originalCrc !== $calculatedCrc) {
                 throw new ParseException(
-                    sprintf('Packet crc (\x%s) does not match calculated crc (\x%s)!',
+                    sprintf(
+                        'Packet crc (\x%s) does not match calculated crc (\x%s)!',
                         bin2hex($originalCrc),
                         bin2hex($calculatedCrc)
                     )

--- a/src/Packet/StartAddressResponse.php
+++ b/src/Packet/StartAddressResponse.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Packet;
-
 
 use ModbusTcpClient\Utils\Endian;
 use ModbusTcpClient\Utils\Types;
@@ -14,7 +14,7 @@ abstract class StartAddressResponse extends ProtocolDataUnit implements ModbusRe
      */
     private int $startAddress;
 
-    public function __construct(string $rawData, int $unitId = 0, int $transactionId = null)
+    public function __construct(string $rawData, int $unitId = 0, ?int $transactionId = null)
     {
         parent::__construct($unitId, $transactionId);
         $this->startAddress = Types::parseUInt16(substr($rawData, 0, 2), Endian::BIG_ENDIAN);

--- a/src/Packet/Word.php
+++ b/src/Packet/Word.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Packet;
@@ -20,7 +21,7 @@ class Word extends AbstractWord
      * @param int|null $endianness byte and word order for modbus binary data
      * @return int
      */
-    public function getInt16(int $endianness = null): int
+    public function getInt16(?int $endianness = null): int
     {
         return Types::parseInt16($this->data, $endianness);
     }
@@ -29,7 +30,7 @@ class Word extends AbstractWord
      * @param int|null $endianness byte and word order for modbus binary data
      * @return int
      */
-    public function getUInt16(int $endianness = null): int
+    public function getUInt16(?int $endianness = null): int
     {
         return Types::parseUInt16($this->data, $endianness);
     }

--- a/src/Utils/Charset.php
+++ b/src/Utils/Charset.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Utils;
-
 
 class Charset
 {
@@ -12,15 +12,15 @@ class Charset
 
     // 'ASCII' is 7-bit charset and 'ISO-8859-1' is 8-bit charset which supports some additional characters.
     // See: https://en.wikipedia.org/wiki/ASCII#Character_set
-    const ASCII = "ASCII";
+    public const ASCII = "ASCII";
     // ISO-8859-1 is a common european encoding, able to encode 'äöåéü' and other characters (for example
     // 'ø' decimal 248), the first 127 characters being the same as in ASCII.
     // See: https://en.wikipedia.org/wiki/ISO/IEC_8859-1#Code_page_layout
-    const ISO_8859_1 = "ISO-8859-1";
+    public const ISO_8859_1 = "ISO-8859-1";
 
     public static string $defaultCharset = self::ISO_8859_1;
 
-    public static function getCurrentEndianness(string $charset = null): string
+    public static function getCurrentEndianness(?string $charset = null): string
     {
         return $charset === null ? static::$defaultCharset : $charset;
     }

--- a/src/Utils/Endian.php
+++ b/src/Utils/Endian.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Utils;
@@ -26,15 +27,15 @@ namespace ModbusTcpClient\Utils;
  */
 class Endian
 {
-    const BIG_ENDIAN = 1;
-    const LITTLE_ENDIAN = 2;
+    public const BIG_ENDIAN = 1;
+    public const LITTLE_ENDIAN = 2;
 
     /**
      * Double words (32bit types) consist of two 16bit words. Different PLCs send double words differently over wire
      * So 0xDCBA can be sent low word (0xBA) first 0xBADC or high word (0xDC) first 0xDCBA. High word first on true big/little endian
      * and does not have separate flag
      */
-    const LOW_WORD_FIRST = 4;
+    public const LOW_WORD_FIRST = 4;
 
     /**
      * Used by WAGO 750-XXX as endianness.
@@ -42,11 +43,11 @@ class Endian
      * When bytes for little endian are in 'ABCD' order then Big Endian Low Word First is in 'BADC' order
      * This mean that high word (BA) is first and low word (DC) for double word is last and bytes in words are in big endian order.
      */
-    const BIG_ENDIAN_LOW_WORD_FIRST = self::BIG_ENDIAN | self::LOW_WORD_FIRST;
+    public const BIG_ENDIAN_LOW_WORD_FIRST = self::BIG_ENDIAN | self::LOW_WORD_FIRST;
 
     public static int $defaultEndian = self::BIG_ENDIAN_LOW_WORD_FIRST;
 
-    public static function getCurrentEndianness(int $endianness = null): int
+    public static function getCurrentEndianness(?int $endianness = null): int
     {
         return $endianness === null ? static::$defaultEndian : $endianness;
     }

--- a/src/Utils/Packet.php
+++ b/src/Utils/Packet.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Utils;
-
 
 use ModbusTcpClient\Network\IOException;
 use ModbusTcpClient\Packet\ErrorResponse;

--- a/src/Utils/Registers.php
+++ b/src/Utils/Registers.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Utils;
-
 
 class Registers
 {

--- a/src/Utils/Types.php
+++ b/src/Utils/Types.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ModbusTcpClient\Utils;
-
 
 use ModbusTcpClient\Exception\InvalidArgumentException;
 use ModbusTcpClient\Exception\OverflowException;
@@ -10,20 +10,20 @@ use ModbusTcpClient\Exception\ParseException;
 
 final class Types
 {
-    const MAX_VALUE_UINT16 = 0xFFFF; // 65535 as dec
-    const MIN_VALUE_UINT16 = 0x0;
+    public const MAX_VALUE_UINT16 = 0xFFFF; // 65535 as dec
+    public const MIN_VALUE_UINT16 = 0x0;
 
-    const MAX_VALUE_INT16 = 0x7FFF; // 32767 as dec
-    const MIN_VALUE_INT16 = -32768; // 0x8000 as hex
+    public const MAX_VALUE_INT16 = 0x7FFF; // 32767 as dec
+    public const MIN_VALUE_INT16 = -32768; // 0x8000 as hex
 
-    const MAX_VALUE_UINT32 = 0xFFFFFFFF; // 4294967295 as dec
-    const MIN_VALUE_UINT32 = 0x0; // 0 as dec
+    public const MAX_VALUE_UINT32 = 0xFFFFFFFF; // 4294967295 as dec
+    public const MIN_VALUE_UINT32 = 0x0; // 0 as dec
 
-    const MAX_VALUE_INT32 = 0x7FFFFFFF; // 2147483647 as dec
-    const MIN_VALUE_INT32 = -2147483648; // 0x80000000 as hex
+    public const MAX_VALUE_INT32 = 0x7FFFFFFF; // 2147483647 as dec
+    public const MIN_VALUE_INT32 = -2147483648; // 0x80000000 as hex
 
-    const MAX_VALUE_BYTE = 0xFF;
-    const MIN_VALUE_BYTE = 0x0;
+    public const MAX_VALUE_BYTE = 0xFF;
+    public const MIN_VALUE_BYTE = 0x0;
 
     private function __construct()
     {
@@ -37,12 +37,12 @@ final class Types
      * @param int|null $fromEndian byte and word order for modbus binary data
      * @return int
      */
-    public static function parseUInt16(string $word, int $fromEndian = null): int
+    public static function parseUInt16(string $word, ?int $fromEndian = null): int
     {
         return unpack(self::getInt16Format($fromEndian), $word)[1];
     }
 
-    private static function getInt16Format(int $fromEndian = null): string
+    private static function getInt16Format(?int $fromEndian = null): string
     {
         $fromEndian = Endian::getCurrentEndianness($fromEndian);
         if ($fromEndian & Endian::BIG_ENDIAN) {
@@ -63,7 +63,7 @@ final class Types
      * @param int|null $fromEndian byte and word order for modbus binary data
      * @return int
      */
-    public static function parseInt16(string $word, int $fromEndian = null): int
+    public static function parseInt16(string $word, ?int $fromEndian = null): int
     {
         $fromEndian = Endian::getCurrentEndianness($fromEndian);
         if ($fromEndian & Endian::BIG_ENDIAN) {
@@ -86,7 +86,7 @@ final class Types
      * @param int|null $fromEndian byte and word order for modbus binary data
      * @return int|float
      */
-    public static function parseUInt32(string $doubleWord, int $fromEndian = null): int|float
+    public static function parseUInt32(string $doubleWord, ?int $fromEndian = null): int|float
     {
         $byteArray = self::getBytesForInt32Parse($doubleWord, $fromEndian);
         if (PHP_INT_SIZE === 4) {
@@ -105,7 +105,7 @@ final class Types
      * @param int|null $fromEndian byte and word order for modbus binary data
      * @return int
      */
-    public static function parseInt32(string $doubleWord, int $fromEndian = null): int
+    public static function parseInt32(string $doubleWord, ?int $fromEndian = null): int
     {
         $byteArray = self::getBytesForInt32Parse($doubleWord, $fromEndian);
         $byteArray['high'] = self::uintToSignedInt($byteArray['high']);
@@ -117,7 +117,7 @@ final class Types
      * @param int|null $endianness
      * @return int[]
      */
-    private static function getBytesForInt32Parse(string $doubleWord, int $endianness = null): array
+    private static function getBytesForInt32Parse(string $doubleWord, ?int $endianness = null): array
     {
         $endianness = Endian::getCurrentEndianness($endianness);
 
@@ -284,7 +284,7 @@ final class Types
      * @param int|null $fromEndian byte and word order for modbus binary data
      * @return float
      */
-    public static function parseFloat(string $binaryData, int $fromEndian = null): float
+    public static function parseFloat(string $binaryData, ?int $fromEndian = null): float
     {
         $fromEndian = Endian::getCurrentEndianness($fromEndian);
         if ($fromEndian & Endian::LOW_WORD_FIRST) {
@@ -313,7 +313,7 @@ final class Types
      * @param int|null $fromEndian byte and word order for modbus binary data
      * @return float
      */
-    public static function parseDouble(string $binaryData, int $fromEndian = null): float
+    public static function parseDouble(string $binaryData, ?int $fromEndian = null): float
     {
         if (PHP_INT_SIZE !== 8) {
             throw new ParseException('64-bit format codes are not available for 32-bit versions of PHP');
@@ -343,7 +343,7 @@ final class Types
      * @param int|null $fromEndian byte and word order for modbus binary data
      * @return int
      */
-    public static function parseUInt64(string $binaryData, int $fromEndian = null): int
+    public static function parseUInt64(string $binaryData, ?int $fromEndian = null): int
     {
         if (strlen($binaryData) !== 8) {
             throw new ParseException('binaryData must be 8 bytes in length');
@@ -384,7 +384,7 @@ final class Types
      * @param int|null $fromEndian byte and word order for modbus binary data
      * @return int
      */
-    public static function parseInt64(string $binaryData, int $fromEndian = null): int
+    public static function parseInt64(string $binaryData, ?int $fromEndian = null): int
     {
         if (strlen($binaryData) !== 8) {
             throw new ParseException('binaryData must be 8 bytes in length');
@@ -419,7 +419,7 @@ final class Types
      * @param int|null $fromEndian byte and word order for modbus binary data
      * @return string
      */
-    public static function parseAsciiStringFromRegister(string $binaryData, int $length = 0, int $fromEndian = null): string
+    public static function parseAsciiStringFromRegister(string $binaryData, int $length = 0, ?int $fromEndian = null): string
     {
         return Types::parseStringFromRegister($binaryData, $length, Charset::$defaultCharset, $fromEndian);
     }
@@ -433,7 +433,7 @@ final class Types
      * @param int|null $fromEndian byte and word order for modbus binary data
      * @return string
      */
-    public static function parseStringFromRegister(string $binaryData, int $length, string $fromEncoding = null, int $fromEndian = null): string
+    public static function parseStringFromRegister(string $binaryData, int $length, ?string $fromEncoding = null, ?int $fromEndian = null): string
     {
         $data = $binaryData;
 
@@ -497,7 +497,7 @@ final class Types
      * @param bool $doRangeCheck should min/max range check be done for data
      * @return string binary string with big endian byte order
      */
-    public static function toInt16(int $data, int $toEndian = null, bool $doRangeCheck = true): string
+    public static function toInt16(int $data, ?int $toEndian = null, bool $doRangeCheck = true): string
     {
         if ($doRangeCheck && ($data < self::MIN_VALUE_INT16 || $data > self::MAX_VALUE_INT16)) {
             throw new OverflowException('Data out of int16 range (-32768...32767)! Given: ' . $data);
@@ -514,7 +514,7 @@ final class Types
      * @param bool $doRangeCheck should min/max range check be done for data
      * @return string binary string with big endian byte order
      */
-    public static function toUint16(int $data, int $toEndian = null, bool $doRangeCheck = true): string
+    public static function toUint16(int $data, ?int $toEndian = null, bool $doRangeCheck = true): string
     {
         if ($doRangeCheck && ($data < self::MIN_VALUE_UINT16 || $data > self::MAX_VALUE_UINT16)) {
             throw new OverflowException('Data out of uint16 range (0...65535)! Given: ' . $data);
@@ -531,7 +531,7 @@ final class Types
      * @param bool $doRangeCheck should min/max range check be done for data
      * @return string binary string with big endian byte order
      */
-    public static function toInt32(int $data, int $toEndian = null, bool $doRangeCheck = true): string
+    public static function toInt32(int $data, ?int $toEndian = null, bool $doRangeCheck = true): string
     {
         if ($doRangeCheck && ($data < self::MIN_VALUE_INT32 || $data > self::MAX_VALUE_INT32)) {
             throw new OverflowException('Data out of int32 range (-2147483648...2147483647)! Given: ' . $data);
@@ -547,7 +547,7 @@ final class Types
      * @param bool $doRangeCheck should min/max range check be done for data
      * @return string binary string with big endian byte order
      */
-    public static function toUint32(int $data, int $toEndian = null, bool $doRangeCheck = true): string
+    public static function toUint32(int $data, ?int $toEndian = null, bool $doRangeCheck = true): string
     {
         if ($doRangeCheck && ($data < self::MIN_VALUE_UINT32 || $data > self::MAX_VALUE_UINT32)) {
             throw new OverflowException('Data out of int32 range (0...4294967295)! Given: ' . $data);
@@ -560,7 +560,7 @@ final class Types
      * @param int|null $endianness
      * @return string
      */
-    private static function toInt32Internal(int $data, int $endianness = null): string
+    private static function toInt32Internal(int $data, ?int $endianness = null): string
     {
         $words = [
             ($data >> 16) & 0xFFFF,
@@ -583,7 +583,7 @@ final class Types
      * @param int|null $toEndian byte and word order for modbus binary data
      * @return string binary string with big endian byte order
      */
-    public static function toInt64(int $data, int $toEndian = null): string
+    public static function toInt64(int $data, ?int $toEndian = null): string
     {
         $words = [
             ($data >> 48) & 0xFFFF,
@@ -609,7 +609,7 @@ final class Types
      * @param bool $doRangeCheck
      * @return string binary string with big endian byte order
      */
-    public static function toUint64(int $data, int $toEndian = null, bool $doRangeCheck = true): string
+    public static function toUint64(int $data, ?int $toEndian = null, bool $doRangeCheck = true): string
     {
         if ($doRangeCheck && $data < 0) {
             throw new OverflowException('Data out of uint64 range (0...9223372036854775807)! Given: ' . $data);
@@ -625,7 +625,7 @@ final class Types
      * @param int|null $toEndian byte and word order for modbus binary data
      * @return string binary string with big endian byte order
      */
-    public static function toReal(float $float, int $toEndian = null): string
+    public static function toReal(float $float, ?int $toEndian = null): string
     {
         $toEndian = Endian::getCurrentEndianness($toEndian);
         $format = 'G'; // double (machine dependent size, big endian byte order)
@@ -647,7 +647,7 @@ final class Types
      * @param int|null $toEndian byte and word order for modbus binary data
      * @return string binary string with big endian byte order
      */
-    public static function toDouble(float $double, int $toEndian = null): string
+    public static function toDouble(float $double, ?int $toEndian = null): string
     {
         $toEndian = Endian::getCurrentEndianness($toEndian);
 
@@ -676,7 +676,7 @@ final class Types
      * @param int|null $toEndian in which endianess and word order resulting binary string should be
      * @return string
      */
-    public static function toString(string $string, int $registersCount, string $toEncoding = null, int $toEndian = null): string
+    public static function toString(string $string, int $registersCount, ?string $toEncoding = null, ?int $toEndian = null): string
     {
         if ($toEncoding !== null) {
             // use 'cp1252' as encoding if you just need extended ASCII chars i.e. chars like 'ø'


### PR DESCRIPTION
With 8.4 PHPStan complains about https://wiki.php.net/rfc/deprecate-implicitly-nullable-types  this PR fixes these 

Fixer is run with
```bash
sudo docker run -it --rm -v $(pwd):/code ghcr.io/php-cs-fixer/php-cs-fixer:${FIXER_VERSION:-3-php8.3} fix --rules nullable_type_declaration_for_default_null_value src
```

PHPStan can be run with
```bash
sudo docker run -it --rm -v .:/code  php:8.4.1-zts-bookworm /bin/sh -c cd /code && vendor/bin/phpstan analyse --no-progres
```